### PR TITLE
Remove UAA_HOST references

### DIFF
--- a/xml/cap_depl_install_minimal.xml
+++ b/xml/cap_depl_install_minimal.xml
@@ -442,15 +442,6 @@ env:
     # The domain you created for your cluster
     DOMAIN: <replaceable>&exampledomain;</replaceable>
     
-    # The fully-qualified domain name of your 
-    # User Account and Authentication (UAA) server
-    # Use the worker you selected for external 
-    # access to your cluster
-    UAA_HOST: <replaceable>uaa-host.&exampledomain;</replaceable>
-    
-    # The default is 2793
-    UAA_PORT: 2793
-    
     # Create a password for your UAA client secret
     UAA_ADMIN_CLIENT_SECRET: <replaceable>password</replaceable>
 

--- a/xml/cap_depl_install_minimal.xml
+++ b/xml/cap_depl_install_minimal.xml
@@ -448,7 +448,8 @@ env:
 kube:
     # The external IP address of the &kube; worker
     # you selected for external access
-    external_ip: <replaceable>&kubeip;</replaceable>
+    external_ips:
+    - <replaceable>&kubeip;</replaceable>
     
     # Your chosen storage class
     storage_class:

--- a/xml/cap_depl_install_production.xml
+++ b/xml/cap_depl_install_production.xml
@@ -288,10 +288,7 @@ Happy Helming!
     <para>
         Create a new configuration file on your workstation for &helm; to use. 
         In this example it is
-        called <filename>scf-config-values.yaml</filename>. Note that the 
-        ingress for a &kube; cluster is not the same as the external access to
-        the &scf; instance, which is defined in 
-        <filename>scf-config-values.yaml</filename> with UAA_HOST.        
+        called <filename>scf-config-values.yaml</filename>.
     </para>
     <screen>
 env:
@@ -300,13 +297,6 @@ env:
     
     # Enter the domain you created for your &kube; cluster
     DOMAIN: <replaceable>&exampledomain;</replaceable>
-    
-    # The fully-qualified domain name of your UAA host
-    # This is the external access to your &scf; instance
-    UAA_HOST: <replaceable>uaa-host.&exampledomain;</replaceable>
-    
-    # The default is 2793
-    UAA_PORT: 2793
     
     # Create a password for your UAA client secret
     UAA_ADMIN_CLIENT_SECRET: <replaceable>changeme</replaceable>

--- a/xml/cap_depl_install_production.xml
+++ b/xml/cap_depl_install_production.xml
@@ -303,7 +303,8 @@ env:
 
 kube:
     # The external IP address of your &kube; cluster
-    external_ip: <replaceable>&kubeip;</replaceable>
+    external_ips: 
+    - <replaceable>&kubeip;</replaceable>
     
     # Your chosen storage class
     storage_class:


### PR DESCRIPTION
The UAA hostname is hardcoded to `uaa.$DOMAIN`, so shouldn't be specified when deploying.

Also, the `external_ip` setting changed to accept a list of IPs, and was renamed to `external_ips` to reflect that.