### PR TITLE
Fixing consul HA sizing

### DIFF
--- a/xml/cap_depl_install_production.xml
+++ b/xml/cap_depl_install_production.xml
@@ -972,7 +972,7 @@ sizing:
   cf_usb:
     count: 2
   consul:
-    count: 3
+    count: 1
   diego_access:
     count: 2
   diego_api:


### PR DESCRIPTION
The deployment of consul currently fails with the following error mesage, if one uses the documented HA sizing of 3:

`error calling fail: consul cannot have more than 1 instances`

Decreasing the size from 3 to 1 makes helm happy and also matches with the
upstream sizing documented on the [SCF wiki ](https://github.com/SUSE/scf/wiki/How-to-Install-SCF#high-availability).