### PR TITLE
Change CaaSP Deployment Guide Links

### DIFF
--- a/xml/cap_depl_install_minimal.xml
+++ b/xml/cap_depl_install_minimal.xml
@@ -43,13 +43,14 @@
  </figure>
  <para>
   This minimal four-node deployment will run on a minimum of 32GB host system
-  memory, though more memory is better. 32GB is enough to test setting up and
-  configuring &suse; &caasp; and &scf;, and to run a few lightweight workloads.
-  You may also test connecting external servers with your cluster, such as a
-  separate name server, a storage server (e.g. &ses;), &scc;, or &smtool;. You
-  must be familiar with installing and configuring &caasp; (see the
-  <link xlink:href="https://www.suse.com/documentation/suse-caasp-2/book_caasp_deployment/index.html">&suse;
-  &caasp; 2 Deployment Guide</link>).
+  memory, though more memory is better. 32GB is enough to test setting up
+  and configuring &suse; &caasp; and &scf;, and to run a few lightweight
+  workloads. You may also test connecting external servers with your cluster,
+  such as a separate name server, a storage server (e.g. &ses;), &scc;, or
+  &smtool;. You must be familiar with installing and configuring &caasp; (see
+  the <link xlink:href=
+  "https://www.suse.com/documentation/suse-caasp-3/book_caasp_deployment/data/book_caasp_deployment.html"
+  >&suse; &caasp; 3 Deployment Guide</link>).
  </para>
  <para>
   After you have installed &caasp; you will install and administer &scf;
@@ -75,10 +76,10 @@
   <important>
    <title>You must be familiar with &suse; &caasp;</title>
    <para>
-    Setting up &suse; &caasp; correctly, and knowledge of basic administration
-    is essential to a successful &productname; deployment. See the
-    <link xlink:href="https://www.suse.com/documentation/suse-caasp-2/book_caasp_deployment/index.html">&suse;
-    &caasp; 2 Deployment Guide</link>
+    Setting up &suse; &caasp; correctly, and knowledge of basic administration is
+    essential to a successful &productname; deployment. See the <link xlink:href=
+    "https://www.suse.com/documentation/suse-caasp-3/book_caasp_deployment/data/book_caasp_deployment.html"
+    >&suse; &caasp; 3 Deployment Guide</link>.
    </para>
   </important>
 
@@ -193,7 +194,7 @@
      </para>
      <para>
       The easiest way to create the &kube; nodes is to use &ay; see
-      <link xlink:href="https://www.suse.com/documentation/suse-caasp-2/book_caasp_deployment/data/sec_caasp_installquick.html#sec_caasp_installquick_node_ay">
+      <link xlink:href="https://www.suse.com/documentation/suse-caasp-3/book_caasp_deployment/data/sec_deploy_nodes_worker_install.html#sec_deploy_nodes_worker_install_manual_autoyast">
       Installation with &ay;</link>. Pass in these kernel boot options to each
       worker: <literal>hostname</literal>, <literal>netsetup</literal>, and the
       &ay; path, which you find in Velum on the "Bootstrap your CaaS Platform"
@@ -209,7 +210,7 @@
      </figure>
      <para>
       When you have completed
-      <link xlink:href="https://www.suse.com/documentation/suse-caasp-2/book_caasp_deployment/data/sec_caasp_installquick.html#sec_caasp_installquick_bootstrap">
+      <link xlink:href="https://www.suse.com/documentation/suse-caasp-3/book_caasp_deployment/data/sec_deploy_install_bootstrap.html">
       Bootstrapping the Cluster</link> open a Web browser to the Velum Web
       interface. If you see a "site not available" or "We're sorry, but
       something went wrong" error wait a few minutes, then try again. Click the

--- a/xml/cap_depl_install_production.xml
+++ b/xml/cap_depl_install_production.xml
@@ -93,8 +93,8 @@
    </varlistentry>
    <varlistentry>
     <term>
-	    Install &suse; &caasp;
-	  </term>
+     Install &suse; &caasp;
+   </term>
     <listitem>
      <para>
       &productname; is supported on &suse; &caasp; 2 and 3. Installation is
@@ -102,10 +102,12 @@
       on setting up &suse; &caasp; 3.
      </para>
      <para>
-      After installing
-      <link xlink:href="https://www.suse.com/documentation/suse-caasp-2/">&caasp;</link>
-      and logging into the Velum Web interface, check the box to install Tiller
-      (&helm;'s server component).
+      After installing <link xlink:href=
+      "https://www.suse.com/documentation/suse-caasp-2/">&caasp;
+      2</link> or <link xlink:href=
+      "https://www.suse.com/documentation/suse-caasp-3/">&caasp;
+      3</link> and logging into the Velum Web interface, check the box
+      to install Tiller (&helm;'s server component).
      </para>
      <figure xml:id="fig.cap.install-tiller-prod">
       <title>Install Tiller</title>
@@ -128,7 +130,7 @@
      <para>
       The easiest way to create the &kube; nodes, after you create the admin
       node, is to use AutoYaST; see
-      <link xlink:href="https://www.suse.com/documentation/suse-caasp-2/book_caasp_deployment/data/sec_caasp_installquick.html#sec_caasp_installquick_node_ay">
+      <link xlink:href="https://www.suse.com/documentation/suse-caasp-3/book_caasp_deployment/data/sec_deploy_nodes_worker_install.html#sec_deploy_nodes_worker_install_manual_autoyast">
       Installation with AutoYaST</link>. Set up &caasp; with one admin node and
       at least three Kubernetes masters and three Kubernetes workers. You also
       need an Internet connection, as the installer downloads additional
@@ -145,7 +147,7 @@
      </figure>
      <para>
       When you have completed
-      <link xlink:href="https://www.suse.com/documentation/suse-caasp-2/book_caasp_deployment/data/sec_caasp_installquick.html#sec_caasp_installquick_bootstrap">
+      <link xlink:href="https://www.suse.com/documentation/suse-caasp-3/book_caasp_deployment/data/sec_deploy_install_bootstrap.html">
       Bootstrapping the Cluster</link> click the <guimenu>kubectl
       config</guimenu> button to download your new cluster's
       <filename>kubeconfig</filename> file. This takes you to a login screen;
@@ -415,7 +417,7 @@ subjects:
    The &kube; cluster requires a persistent storage class for the databases to
    store persistent data. Your available storage classes depend on which
    storage cluster you are using (&ses; users, see
-   <link xlink:href="https://www.suse.com/documentation/suse-caasp-2/book_caasp_deployment/data/integration.html">&suse;
+   <link xlink:href="https://www.suse.com/documentation/suse-caasp-3/book_caasp_admin/data/cha_admin_integration.html">&suse;
    &caasp; Integration with SES</link>). After connecting your storage backend
    use <command>kubectl</command> to see your available storage classes:
   </para>

--- a/xml/cap_depl_intro.xml
+++ b/xml/cap_depl_intro.xml
@@ -30,7 +30,7 @@
  <para>
   &scf; is designed to run on any Kubernetes cluster. This guide describes how
   to deploy it on
-  <link xlink:href="https://www.suse.com/documentation/suse-caasp-2/book_caasp_deployment/data/book_caasp_deployment.html">SUSE
+  <link xlink:href="https://www.suse.com/documentation/suse-caasp-3/book_caasp_deployment/data/book_caasp_deployment.html">SUSE
   Container as a Service (CaaS) Platform 2.0</link>.
  </para>
  <xi:include href="common_intro_target_audience_i.xml"/>

--- a/xml/cap_depl_prerequisites.xml
+++ b/xml/cap_depl_prerequisites.xml
@@ -47,7 +47,7 @@ the &kube; master and workers.
 	  <para>
 	    This requires a minimum of four physical or virtual nodes: one admin, one 
         Kubernetes master, and two Kubernetes minions. (See the 
-        <link xlink:href="https://www.suse.com/documentation/suse-caasp-2/">CaaSP 
+        <link xlink:href="https://www.suse.com/documentation/suse-caasp-3/">CaaSP
         documentation</link>). You also need an Internet connection, as the 
         installer downloads additional packages, and the &kube;
         minions will download 8-10GB of Docker images each.
@@ -63,9 +63,9 @@ the &kube; master and workers.
       <para>
           The easiest way to create the Kubernetes nodes, after you create the 
           admin node, is to use AutoYaST; see 
-<link xlink:href="https://www.suse.com/documentation/suse-caasp-2/book_caasp_deployment/data/sec_caasp_installquick.html#sec_caasp_installquick_node_ay">
+<link xlink:href="https://www.suse.com/documentation/suse-caasp-3/book_caasp_deployment/data/sec_deploy_nodes_worker_install.html#sec_deploy_nodes_worker_install_manual_autoyast">
               Installation with AutoYaST</link>. When you have completed 
-<link xlink:href="https://www.suse.com/documentation/suse-caasp-2/book_caasp_deployment/data/sec_caasp_installquick.html#sec_caasp_installquick_bootstrap">
+<link xlink:href="https://www.suse.com/documentation/suse-caasp-3/book_caasp_deployment/data/sec_deploy_install_bootstrap.html">
               Bootstrapping the Cluster</link> you can proceed to 
           satisfying the remaining prerequisites, and then installing &productname;.
       </para>
@@ -133,9 +133,9 @@ the &kube; master and workers.
 	</varlistentry>
 <varlistentry>
  <term>
-     kube-dns must be installed and running
+  kube-dns must be installed and running. This is the default for
+  &caasp; 2 and 3.
  </term>
- <!-- cwickert 2018-01-15: kube-dns is included in CaaSP 2 by default -->
   <listitem>
    <para>
      Install kube-dns on your kube-master and verify with these commands:
@@ -144,10 +144,7 @@ the &kube; master and workers.
  
 &prompt.root;kubectl cluster-info 
   Kubernetes master is running at http://localhost:8080
-  KubeDNS is running at http://localhost:8080/api/v1/proxy/namespaces/kube-system/services/kube-dns</screen> 
-<!-- cwickert 2018-01-15: link outdated; section was removed from the CaaSP 2
- docs as kube-dns is installed by default -->
-(See (<link xlink:href="https://www.suse.com/documentation/suse-caasp-1/singlehtml/book_caasp_deployment/book_caasp_deployment.html#installing.dns">Installing Kubernetes DNS</link>)
+  KubeDNS is running at http://localhost:8080/api/v1/proxy/namespaces/kube-system/services/kube-dns</screen>
   </para>
  </listitem>
 </varlistentry>    


### PR DESCRIPTION
* CaaSP 3 section and chapter names changed, updated
  links accordingly
* Link to the v3 Release of CaaSP documentation instead of v2
* Link to CaaSP Deployment Guide instead of Quick Start