### PR TITLE
Add kubectl install with zypper

### DIFF
--- a/xml/cap_depl_install_production.xml
+++ b/xml/cap_depl_install_production.xml
@@ -167,11 +167,14 @@
     <term>Install kubectl</term>
     <listitem>
      <para>
-      Follow the instructions at
-      <link xlink:href="https://kubernetes.io/docs/tasks/tools/install-kubectl/">
-      Install and Set Up kubectl</link> to install <command>kubectl</command>
-      on your workstation. After installation, run this command to verify that
-      it is installed, and that is communicating correctly with your cluster:
+      To install <command>kubectl</command> on a &slea; 12 SP3 or 15
+      workstation, install the package
+      <package>kubernetes-client</package> from the <emphasis>Public
+      Cloud</emphasis> module. For other operating systems, follow the
+      instructions at <link xlink:href=
+      "https://kubernetes.io/docs/tasks/tools/install-kubectl/" />. After
+      installation, run this command to verify that it is installed,
+      and that is communicating correctly with your cluster:
      </para>
 <screen>&prompt.user;kubectl version --short
 Client Version: v1.9.1


### PR DESCRIPTION
kubectl is available in the Public Cloud module. We should point users to that package because it's the easiest way to install it on SLE.