### PR TITLE
Update terminology for adding charts

### DIFF
--- a/xml/cap_depl_install_minimal.xml
+++ b/xml/cap_depl_install_minimal.xml
@@ -527,7 +527,7 @@ secrets:
   </itemizedlist>
 
   <sect2 xml:id="sec.cap.addrepo-min">
-   <title>Install the &kube; charts repository</title>
+   <title>Add the &kube; charts repository</title>
    <para>
     Download the &suse; &kube; charts repository with &helm;:
    </para>

--- a/xml/cap_depl_install_production.xml
+++ b/xml/cap_depl_install_production.xml
@@ -605,7 +605,7 @@ secrets:
   </procedure>
  </sect1>
  <sect1 xml:id="sec.cap.addrepo-prod">
-  <title>Install the &kube; charts repository</title>
+  <title>Add the &kube; charts repository</title>
 
   <para>
    Download the &suse; &kube; charts repository with &helm;:


### PR DESCRIPTION
Updating as requested by Troy.

```
 "Install the Kubernetes charts repository" is really incorrect wording in the docs
should probably be "add"
```