### PR TITLE
Storage class set in values.yaml will be used. No need to set again

### DIFF
--- a/xml/cap_depl_stratos.xml
+++ b/xml/cap_depl_stratos.xml
@@ -51,15 +51,14 @@ suse/console                 &lateststratoschart;   A Helm chart for deploying S
 suse/uaa                     &latestuaachart;  A Helm chart for SUSE UAA</screen>
 
   <para>
-   Install Stratos, and if you have not set a default storage class you must
-   specify it:
+   Use &helm; to install Stratos:
   </para>
 
 <screen>&prompt.user;helm install suse/console \
     --name <replaceable>susecf-console</replaceable> \
     --namespace stratos \
     --values scf-config-values.yaml \
-    --set storageClass=<replaceable>persistent</replaceable></screen>
+</screen>
 
   <para>
    Monitor progress:


### PR DESCRIPTION
Update as per Rocket Chat discussion:

```
if you use your SCF config values when installing Stratos, we will 
use the storage class configured there, so it does not have to be 
set as the default. If you install Stratos without the SCF config values, 
then we will use the default storage class if one is not specified, hence 
the recommendation to have a default. Your example showing the 
SCF config values and setting the storageClass is indeed a little 
confusing, since you don't need to specify the storage class if its 
already set in the scf config values - I think this might date back to 
a time when you did - but that example should be updated.
```