### PR TITLE
fixed missing serviceaccount in PSP definition

### DIFF
--- a/xml/cap_depl_install_production.xml
+++ b/xml/cap_depl_install_production.xml
@@ -444,7 +444,13 @@ subjects:
   namespace: scf
 - kind: ServiceAccount
   name: default
-  namespace: stratos</screen>
+  namespace: stratos
+- kind: ServiceAccount
+  name: default-privileged
+  namespace: scf
+- kind: ServiceAccount
+  name: node-reader
+  namespace: scf</screen>
    <para>
     Apply it to your cluster with <command>kubectl</command>:
    </para>


### PR DESCRIPTION
Added the serviceaccounts for diego-cell, nfsbroker and router to the PSP definition for CaaSP.
see https://github.com/SUSE/doc-cap/issues/312