### PR TITLE
Start breaking out repeated content into xincludes

### DIFF
--- a/xml/book_cap_guides.xml
+++ b/xml/book_cap_guides.xml
@@ -49,7 +49,8 @@ Part: CAP Deployment Guide
  <part xml:id="part.cap.deployment">
   <title>Deploying &productname;</title>
   <info/>
-<xi:include href="cap_depl_install_production.xml"/>
+<xi:include href="cap_depl_admin_notes.xml"/> 
+<xi:include href="cap_depl_install_caasp.xml"/>
 <xi:include href="cap_depl_stratos.xml"/>
 <xi:include href="cap_depl_ha.xml"/>
 <xi:include href="cap_depl_ldap.xml"/>

--- a/xml/cap_admin_service_broker.xml
+++ b/xml/cap_admin_service_broker.xml
@@ -73,14 +73,14 @@
 
   <para>
    If you are deploying &productname; on &caasp; 3, see
-   <xref linkend="sec.cap.caasp-3"/> for important information on applying the
+   <!--TODO fixme--> for important information on applying the
    required PodSecurityPolicy (PSP) to your deployment. You must also apply the
    PSP to your new service brokers.
   </para>
 
   <para>
    Take the example configuration file, <filename>cap-psp-rbac.yaml</filename>,
-   in <xref linkend="sec.cap.caasp-3"/>, and append these lines to the end,
+   in <!--TODO fixme-->, and append these lines to the end,
    using your own namespace name for your new service broker:
   </para>
 

--- a/xml/cap_depl_admin_notes.xml
+++ b/xml/cap_depl_admin_notes.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE chapter
+[
+  <!ENTITY % entities SYSTEM "entity-decl.ent">
+    %entities;
+]>
+<chapter version="5.0" xml:id="cha.cap.depl.notes"
+  xmlns="http://docbook.org/ns/docbook"
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+ <info>
+  <title>Deployment and Administration Notes</title>
+  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+   <dm:bugtracker></dm:bugtracker>
+   <dm:translation>yes</dm:translation>
+  </dm:docmanager>
+ </info>  
+  <para>
+      Some tips, tricks, and traps.</para>     
+<xi:include href="sec_cap_depl_admin_notes.xml"/>
+  </chapter>
+

--- a/xml/cap_depl_azure.xml
+++ b/xml/cap_depl_azure.xml
@@ -355,7 +355,7 @@ subjects:
 
   <para>
    Role-based access control (RBAC) is enabled by default on AKS. Follow the
-   instructions in <xref linkend="sec.cap.caasp-3"/> to apply pod security
+   instructions in <!--TODO fixme--> to apply pod security
    policies (PSPs) to your new AKS cluster.
   </para>
 

--- a/xml/cap_depl_install_caasp.xml
+++ b/xml/cap_depl_install_caasp.xml
@@ -289,6 +289,8 @@ Happy Helming!</screen>
      </para>
     </listitem>
    </itemizedlist>
+   
+   <!--TODO add info on custom PSPs -->
    <para>
        &productname; includes the necessary PSP configurations in the &helm; 
        charts to run on &suse; &caasp;,

--- a/xml/cap_depl_install_caasp.xml
+++ b/xml/cap_depl_install_caasp.xml
@@ -42,44 +42,14 @@
   <xref linkend="sec.cap.ha-prod"/>.
  </para>
  
-<sect1 xml:id="sec.cap.deploy-notes">
-  <title>Deployment and Administration Notes</title>
-  <para>
-      This section lists considerations for deploying and operating
-      &productname;.
-  </para>
-  
-  <variablelist>
-   <varlistentry>
-       <term>Length of release names</term>
-       <listitem>
-           <para>Release names (e.g. when you run 
-               <command>helm install --name</command>) have a maximum length of 
-               36 characters.</para>
-       </listitem>
-  </varlistentry>
-   <varlistentry>
-       <term>Always install to a fresh namespace</term>
-       <listitem>
-       <para>    
-    If you are not creating a fresh &productname; installation, but have deleted 
-    a previous deployment and are starting over, you must create new namespaces
-    with the 
-    <command>kubectl create namespace <replaceable>name</replaceable></command>
-        command. 
-    Do not re-use your old namespaces. The <command>helm delete</command> command 
-    does not remove generated secrets from the SCF and UAA namespaces as it is 
-    not aware of them. These leftover secrets will cause problems. See 
-    <xref linkend="sec.cap.rebuild.depl"/> for more information.
-    </para>
-       </listitem>
-  </varlistentry> 
-  </variablelist>
-</sect1>
-
-  <sect1 xml:id="sec.cap.prereqs-prod">
+   <sect1 xml:id="sec.cap.prereqs-prod">
   <title>Prerequisites</title>
-
+  <important>
+      <title>README first!</title>
+      <para>Before you start deploying &productname; review the <link xlink:href="https://www.suse.com/releasenotes/">Release Notes</link> and 
+          <xref linkend="cha.cap.depl.notes"/>.
+      </para>
+    </important>
   <para>
    Calculating hardware requirements is best done with an analysis of your
    expected workloads, traffic patterns, storage needs, and application
@@ -131,9 +101,7 @@
     <term>Install &suse; &caasp;</term>
     <listitem>
      <para>
-      &productname; is supported on &suse; &caasp; 2 and 3. Installation is
-      similar for both; see <xref linkend="sec.cap.caasp-3"/> for special notes
-      on setting up &suse; &caasp; 3.
+      &productname; is supported on &suse; &caasp; 3.x.
      </para>
      <para>
       After installing
@@ -295,11 +263,12 @@ Happy Helming!</screen>
     </listitem>
    </varlistentry>
   </variablelist>
+</sect1>
 
-  <sect2 xml:id="sec.cap.caasp-3">
-   <title>&suse; &caasp; 3 PodSecurityPolicy</title>
-   <para>
-    &suse; &caasp; 3 introduces PodSecurityPolicy (PSP) support. This change
+<sect1 xml:id="sec.cap.psps">
+  <title>PodSecurityPolicy</title>
+  <para>
+    &suse; &caasp; 3 includes PodSecurityPolicy (PSP) support. This change
     adds two new PSPs to &caasp; 3:
    </para>
    <itemizedlist>
@@ -321,6 +290,11 @@ Happy Helming!</screen>
     </listitem>
    </itemizedlist>
    <para>
+       &productname; includes the necessary PSP configurations in the &helm; 
+       charts to run on &suse; &caasp;,
+       and are set up automatically without requiring manual configuration.
+   </para>
+   <para>
     See
     <link xlink:href="https://kubernetes.io/docs/concepts/policy/pod-security-policy/">
     Pod Security Policies</link>,
@@ -329,181 +303,9 @@ Happy Helming!</screen>
     <link xlink:href="https://docs.cloudfoundry.org/uaa/identity-providers.html#id-flow">
     Identity Provider Workflow</link> for more information.
    </para>
-   <para>
-    Currently, all the pods are created using the default
-    <literal>serviceAccount</literal> in their namespaces in order to apply the
-    <literal>unprivileged</literal> PSP. Consequently, some pods cannot be
-    created because privileged mode and privilege escalation are disabled by
-    default. (error: cannot set allowPrivilegeEscalation to
-    <literal>false</literal> and <literal>privileged</literal> to true).
-   </para>
-   <para>
-    To get around this, create a configuration file called
-    <filename>cap-psp-rbac.yaml</filename>. This enables both privileged mode
-    and privilege escalation. You need a running &caasp; cluster, and
-    <command>kubectl</command> configured and working. You will apply this file
-    before you deploy UAA and SCF.
-   </para>
-   <para>
-    Copy the following example into <filename>cap-psp-rbac.yaml</filename>:
-   </para>
-<screen>---
-apiVersion: extensions/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: suse.cap.psp
-  annotations:
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
-spec:
-  # Privileged
-  #default in suse.caasp.psp.unprivileged
-  #privileged: false
-  privileged: true
-  # Volumes and File Systems
-  volumes:
-    # Kubernetes Pseudo Volume Types
-    - configMap
-    - secret
-    - emptyDir
-    - downwardAPI
-    - projected
-    - persistentVolumeClaim
-    # Networked Storage
-    - nfs
-    - rbd
-    - cephFS
-    - glusterfs
-    - fc
-    - iscsi
-    # Cloud Volumes
-    - cinder
-    - gcePersistentDisk
-    - awsElasticBlockStore
-    - azureDisk
-    - azureFile
-    - vsphereVolume
-  allowedFlexVolumes: []
-  # hostPath volumes are not allowed; pathPrefix must still be specified
-  allowedHostPaths:      
-    - pathPrefix: /opt/kubernetes-hostpath-volumes
-  readOnlyRootFilesystem: false
-  # Users and groups
-  runAsUser:
-    rule: RunAsAny
-  supplementalGroups:
-    rule: RunAsAny
-  fsGroup:
-    rule: RunAsAny
-  # Privilege Escalation
-  #default in suse.caasp.psp.unprivileged
-  #allowPrivilegeEscalation: false
-  allowPrivilegeEscalation: true
-  #default in suse.caasp.psp.unprivileged
-  #defaultAllowPrivilegeEscalation: false
-  # Capabilities
-  allowedCapabilities:
-  - SYS_RESOURCE
-  defaultAddCapabilities: []
-  requiredDropCapabilities: []
-  # Host namespaces
-  hostPID: false
-  hostIPC: false
-  hostNetwork: false
-  hostPorts:
-  - min: 0
-    max: 65535
-  # SELinux
-  seLinux:
-    # SELinux is unsed in CaaSP
-    rule: 'RunAsAny'
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: suse:cap:psp
-rules:
-- apiGroups: ['extensions']
-  resources: ['podsecuritypolicies']
-  verbs: ['use']
-  resourceNames: ['suse.cap.psp']
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: cap:clusterrole
-roleRef:
-  kind: ClusterRole
-  name: suse:cap:psp
-  apiGroup: rbac.authorization.k8s.io
-subjects:
-- kind: ServiceAccount
-  name: default
-  namespace: uaa
-- kind: ServiceAccount
-  name: default
-  namespace: scf
-- kind: ServiceAccount
-  name: default
-  namespace: stratos
-- kind: ServiceAccount
-  name: default-privileged
-  namespace: scf
-- kind: ServiceAccount
-  name: node-reader
-  namespace: scf</screen>
-   <para>
-    Apply it to your cluster with <command>kubectl</command>:
-   </para>
-<screen>&prompt.user;kubectl create -f cap-psp-rbac.yaml
-podsecuritypolicy.extensions "suse.cap.psp" created
-clusterrole.rbac.authorization.k8s.io "suse:cap:psp" created
-clusterrolebinding.rbac.authorization.k8s.io "cap:clusterrole" created</screen>
-   <para>
-    Verify that the new PSPs exist by running the <command>kubectl get
-    psp</command> command to list them. Then continue by deploying UAA and SCF.
-    Ensure that your <filename>scf-config-values.yaml</filename> file specifies
-    the name of your PSP in the <literal>kube:</literal> section. These
-    settings will grant only a limited subset of roles to be privileged.
-   </para>
-<screen>kube:
-  psp:
-    privileged: "suse.cap.psp"
-</screen>
+</sect1>
 
-<tip>
-    <para>
-        Note that the example <filename>cap-psp-rbac.yaml</filename> file sets
-        the name of the PSPs, which in the previous examples is
-        <literal>suse.cap.psp</literal>.
-    </para>
-</tip>
-   <important>
-    <title>Using Custom PodSecurityPolicies</title>
-    <para>
-     When using a custom PSP, your <filename>scf-config-values.yaml</filename> file will require the <literal>SYS_RESOURCE</literal> capability to be added to some roles as follows:
-    </para>
-    <screen>
-sizing:
-  cc_uploader:
-    capabilities: ["SYS_RESOURCE"]
-  diego_api:
-    capabilities: ["SYS_RESOURCE"]
-  diego_brain:
-    capabilities: ["SYS_RESOURCE"]
-  diego_ssh:
-    capabilities: ["SYS_RESOURCE"]
-  nats:
-    capabilities: ["SYS_RESOURCE"]
-  router:
-    capabilities: ["SYS_RESOURCE"]
-  routing_api:
-    capabilities: ["SYS_RESOURCE"]
-    </screen>
-   </important>
-  </sect2>
-  
- </sect1>
- <sect1 xml:id="sec.cap.storageclass-prod">
+<sect1 xml:id="sec.cap.storageclass-prod">
   <title>Choose Storage Class</title>
 
   <para>
@@ -778,22 +580,6 @@ sed's/"namespace": "default"/"namespace": "scf"/' | kubectl create -f -</screen>
  </sect1>
  <sect1 xml:id="sec.cap.install-uaa-prod">
   <title>Deploy UAA</title>
-
-  <important>
-   <title>Always install to a fresh namespace</title>
-   <para>
-    If you are not creating a fresh &productname; installation, but have deleted 
-    a previous deployment and are starting over, you must create new namespaces
-    with the 
-    <command>kubectl create namespace <replaceable>name</replaceable></command>
-        command. 
-    Do not re-use your old namespaces. The <command>helm delete</command> command 
-    does not remove generated secrets from the SCF and UAA namespaces as it is 
-    not aware of them. These leftover secrets will cause problems. See 
-    <xref linkend="sec.cap.rebuild.depl"/> for more information.
-   </para>
-  </important>
-
   <para>
    Use &helm; to deploy the UAA (User Account and Authentication) server. You
    may create your own release <literal>--name</literal>:
@@ -835,18 +621,6 @@ post-deployment-setup-1-hnpln   0/1       Completed</screen>
  </sect1>
  <sect1 xml:id="sec.cap.install-scf-prod">
   <title>Deploy SCF</title>
-
-  <important>
-   <title>Always install to a fresh namespace</title>
-   <para>
-    If you are not creating a fresh &productname; installation, but have deleted 
-    a previous deployment and are starting over, you must create new namespaces. 
-    Do not re-use your old namespaces. The <command>helm delete</command> command 
-    does not remove generated secrets from the SCF and UAA namespaces as it is 
-    not aware of them. These leftover secrets will cause problems. See 
-    <xref linkend="sec.cap.rebuild.depl"/> for more information.
-   </para>
-  </important>
 
   <para>
    First pass your UAA secret and certificate to SCF, then use &helm; to

--- a/xml/sec_cap_depl_admin_notes.xml
+++ b/xml/sec_cap_depl_admin_notes.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sect1
+[
+  <!ENTITY % entities SYSTEM "entity-decl.ent">
+    %entities;
+]>
+<sect1
+ xmlns="http://docbook.org/ns/docbook"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink"
+ version="5.0">
+
+ <title>
+      Considerations for deploying and operating &productname;.
+  </title>
+
+  <variablelist>
+         <varlistentry>
+       <term>DNS management</term>
+       <!--TODO link to DNS requirements section, when it exists -->
+       <listitem>
+           <para>You must have control of your own DNS management, and set
+               up all the necessary domains and subdomains for &productname;
+               and your applications.</para>
+       </listitem>
+  </varlistentry>
+   <varlistentry>
+       <term>Length of release names</term>
+       <listitem>
+           <para>Release names (e.g. when you run 
+               <command>helm install --name</command>) have a maximum length of 
+               36 characters.</para>
+       </listitem>
+  </varlistentry>
+   <varlistentry>
+       <term>Always install to a fresh namespace</term>
+       <listitem>
+       <para>    
+    If you are not creating a fresh &productname; installation, but have deleted 
+    a previous deployment and are starting over, you must create new namespaces
+    with the 
+    <command>kubectl create namespace <replaceable>name</replaceable></command>
+        command. 
+    Do not re-use your old namespaces. The <command>helm delete</command> command 
+    does not remove generated secrets from the SCF and UAA namespaces as it is 
+    not aware of them. These leftover secrets will cause problems. See 
+    <xref linkend="sec.cap.rebuild.depl"/> for more information.
+    </para>
+       </listitem>
+  </varlistentry> 
+  </variablelist>
+</sect1>

--- a/xml/sec_psps.xml
+++ b/xml/sec_psps.xml
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sect2
+[
+  <!ENTITY % entities SYSTEM "entity-decl.ent">
+    %entities;
+]>
+<sect2
+ xmlns="http://docbook.org/ns/docbook"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink"
+ version="5.0">
+    
+   <title>&suse; &caasp; 3 PodSecurityPolicy</title>
+
+   <para>
+    Currently, all the pods are created using the default
+    <literal>serviceAccount</literal> in their namespaces in order to apply the
+    <literal>unprivileged</literal> PSP. Consequently, some pods cannot be
+    created because privileged mode and privilege escalation are disabled by
+    default. (error: cannot set allowPrivilegeEscalation to
+    <literal>false</literal> and <literal>privileged</literal> to true).
+   </para>
+   <para>
+    To get around this, create a configuration file called
+    <filename>cap-psp-rbac.yaml</filename>. This enables both privileged mode
+    and privilege escalation. You need a running &caasp; cluster, and
+    <command>kubectl</command> configured and working. You will apply this file
+    before you deploy UAA and SCF.
+   </para>
+   <para>
+    Copy the following example into <filename>cap-psp-rbac.yaml</filename>:
+   </para>
+<screen>---
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: suse.cap.psp
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+spec:
+  # Privileged
+  #default in suse.caasp.psp.unprivileged
+  #privileged: false
+  privileged: true
+  # Volumes and File Systems
+  volumes:
+    # Kubernetes Pseudo Volume Types
+    - configMap
+    - secret
+    - emptyDir
+    - downwardAPI
+    - projected
+    - persistentVolumeClaim
+    # Networked Storage
+    - nfs
+    - rbd
+    - cephFS
+    - glusterfs
+    - fc
+    - iscsi
+    # Cloud Volumes
+    - cinder
+    - gcePersistentDisk
+    - awsElasticBlockStore
+    - azureDisk
+    - azureFile
+    - vsphereVolume
+  allowedFlexVolumes: []
+  # hostPath volumes are not allowed; pathPrefix must still be specified
+  allowedHostPaths:      
+    - pathPrefix: /opt/kubernetes-hostpath-volumes
+  readOnlyRootFilesystem: false
+  # Users and groups
+  runAsUser:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  fsGroup:
+    rule: RunAsAny
+  # Privilege Escalation
+  #default in suse.caasp.psp.unprivileged
+  #allowPrivilegeEscalation: false
+  allowPrivilegeEscalation: true
+  #default in suse.caasp.psp.unprivileged
+  #defaultAllowPrivilegeEscalation: false
+  # Capabilities
+  allowedCapabilities:
+  - SYS_RESOURCE
+  defaultAddCapabilities: []
+  requiredDropCapabilities: []
+  # Host namespaces
+  hostPID: false
+  hostIPC: false
+  hostNetwork: false
+  hostPorts:
+  - min: 0
+    max: 65535
+  # SELinux
+  seLinux:
+    # SELinux is unsed in CaaSP
+    rule: 'RunAsAny'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: suse:cap:psp
+rules:
+- apiGroups: ['extensions']
+  resources: ['podsecuritypolicies']
+  verbs: ['use']
+  resourceNames: ['suse.cap.psp']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cap:clusterrole
+roleRef:
+  kind: ClusterRole
+  name: suse:cap:psp
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: uaa
+- kind: ServiceAccount
+  name: default
+  namespace: scf
+- kind: ServiceAccount
+  name: default
+  namespace: stratos
+- kind: ServiceAccount
+  name: default-privileged
+  namespace: scf
+- kind: ServiceAccount
+  name: node-reader
+  namespace: scf</screen>
+   <para>
+    Apply it to your cluster with <command>kubectl</command>:
+   </para>
+<screen>&prompt.user;kubectl create -f cap-psp-rbac.yaml
+podsecuritypolicy.extensions "suse.cap.psp" created
+clusterrole.rbac.authorization.k8s.io "suse:cap:psp" created
+clusterrolebinding.rbac.authorization.k8s.io "cap:clusterrole" created</screen>
+   <para>
+    Verify that the new PSPs exist by running the <command>kubectl get
+    psp</command> command to list them. Then continue by deploying UAA and SCF.
+    Ensure that your <filename>scf-config-values.yaml</filename> file specifies
+    the name of your PSP in the <literal>kube:</literal> section. These
+    settings will grant only a limited subset of roles to be privileged.
+   </para>
+<screen>kube:
+  psp:
+    privileged: "suse.cap.psp"
+</screen>
+
+<tip>
+    <para>
+        Note that the example <filename>cap-psp-rbac.yaml</filename> file sets
+        the name of the PSPs, which in the previous examples is
+        <literal>suse.cap.psp</literal>.
+    </para>
+</tip>
+   <important>
+    <title>Using Custom PodSecurityPolicies</title>
+    <para>
+     When using a custom PSP, your <filename>scf-config-values.yaml</filename> file will require the <literal>SYS_RESOURCE</literal> capability to be added to some roles as follows:
+    </para>
+    <screen>
+sizing:
+  cc_uploader:
+    capabilities: ["SYS_RESOURCE"]
+  diego_api:
+    capabilities: ["SYS_RESOURCE"]
+  diego_brain:
+    capabilities: ["SYS_RESOURCE"]
+  diego_ssh:
+    capabilities: ["SYS_RESOURCE"]
+  nats:
+    capabilities: ["SYS_RESOURCE"]
+  router:
+    capabilities: ["SYS_RESOURCE"]
+  routing_api:
+    capabilities: ["SYS_RESOURCE"]
+    </screen>
+   </important>
+  </sect2>


### PR DESCRIPTION
which allows embedding repeated content, rather than creating 
cross-references. And reduce the numbers of repeated warnings, which
are annoying and cluttery. This is the first of multiple PRs, to keep them at manageable sizes.