### PR TITLE
Update note about service broker url when upgrading from 1.3 to 1.3.1

### DIFF
--- a/xml/cap_admin_service_broker.xml
+++ b/xml/cap_admin_service_broker.xml
@@ -396,40 +396,8 @@ mysql-service  1        Mon May 21 11:40:11 2018  DEPLOYED  cf-usb-sidecar-mysql
  <sect1 xml:id="sec.cap.service-broker-upgrades">
   <title>Upgrade Notes</title>
 
-  <para>
-   This change is only applicable for upgrades from &cap; 1.2.1 to &cap; 1.3.
-   The URL of the internal cf-usb broker endpoint has changed. Brokers for
-   PostgreSQL and MySQL that use cf-usb will require the following manual fix
-   after upgrading to reconnect with SCF/CAP:
-  </para>
+  <!-- Internal cf-usb broker broker endpoint URL change involving 1.3 -->
+  <xi:include href="sec_cf_usb_url.xml"/>
 
-  <para>
-   Get the name of the secret (e.g. <literal>secrets-2.14.5-1</literal>):
-  </para>
-
-<screen>&prompt.user;kubectl get secret --namespace scf</screen>
-
-  <para>
-   Get the URL of the <literal>cf-usb</literal> host (e.g.
-   <literal>https://cf-usb.scf.svc.cluster.local:24054/</literal>):
-  </para>
-
-<screen>&prompt.user;cf service-brokers</screen>
-
-  <para>
-   Get the current <literal>cf-usb</literal> password, where
-   <literal>&lt;secret_name></literal> is the name from the first step:
-  </para>
-
-<screen>&prompt.user;kubectl get secret --namespace scf <replaceable>&lt;secret_name></replaceable> -o yaml | grep \\scf-usb-password: | cut -d: -f2 | base64 -id</screen>
-
-  <para>
-   Update the service broker, where <literal>&lt;password></literal> is the
-   password from the previous step, and the URL is the result of the second
-   step with the leading <literal>cf-usb</literal> part doubled with a dash
-   separator
-  </para>
-
-<screen>&prompt.user;cf update-service-broker usb broker-admin <replaceable>&lt;password></replaceable> <replaceable>https://cf-usb-cf-usb.scf.svc.cluster.local:24054</replaceable></screen>
  </sect1>
 </chapter>

--- a/xml/cap_admin_upgrade.xml
+++ b/xml/cap_admin_upgrade.xml
@@ -202,37 +202,6 @@ suse/uaa        2.7.0       A Helm chart for SUSE UAA
 <screen>&prompt.user;helm upgrade --recreate-pods <replaceable>susecf-scf</replaceable> suse/cf \
 --values scf-config-values.yaml --set "secrets.UAA_CA_CERT=${CA_CERT}"</screen>
 
-  <important>
-   <title>Change in URL of internal cf-usb broker endpoint</title>
-   <para>
-    This change is only applicable for upgrades from &cap; 1.2.1 to &cap; 1.3.
-    The URL of the internal cf-usb broker endpoint has changed. Brokers for
-    PostgreSQL and MySQL that use cf-usb will require the following manual fix
-    after upgrading to reconnect with SCF/CAP:
-   </para>
-   <para>
-    Get the name of the secret (e.g. <literal>secrets-2.14.5-1</literal>):
-   </para>
-<screen>&prompt.user;kubectl get secret --namespace scf</screen>
-   <para>
-    Get the URL of the <literal>cf-usb</literal> host (e.g.
-    <literal>https://cf-usb.scf.svc.cluster.local:24054/</literal>):
-   </para>
-<screen>&prompt.user;cf service-brokers</screen>
-   <para>
-    Get the current <literal>cf-usb</literal> password, where
-    <literal>&lt;secret_name></literal> is the name from the first step:
-   </para>
-<screen>&prompt.user;kubectl get secret --namespace scf <replaceable>&lt;secret_name></replaceable> -o yaml | grep \\scf-usb-password: | cut -d: -f2 | base64 -id</screen>
-   <para>
-    Update the service broker, where <literal>&lt;password></literal> is the
-    password from the previous step, and the URL is the result of the second
-    step with the leading <literal>cf-usb</literal> part doubled with a dash
-    separator
-   </para>
-<screen>&prompt.user;cf update-service-broker usb broker-admin <replaceable>&lt;password></replaceable> <replaceable>https://cf-usb-cf-usb.scf.svc.cluster.local:24054</replaceable></screen>
-  </important>
-
   <para>
    Then upgrade Stratos:
   </para>
@@ -244,6 +213,10 @@ suse/uaa        2.7.0       A Helm chart for SUSE UAA
    Your pods will be unavailable to answer requests until the upgrade is
    complete.
   </para>
+
+  <!-- Internal cf-usb broker broker endpoint URL change involving 1.3 -->
+  <xi:include href="sec_cf_usb_url.xml"/>
+
  </sect1>
  <sect1 xml:id="sec.cap.skipped-release">
   <title>Installing Skipped Releases</title>

--- a/xml/sec_cf_usb_url.xml
+++ b/xml/sec_cf_usb_url.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sect2
+[
+  <!ENTITY % entities SYSTEM "entity-decl.ent">
+    %entities;
+]>
+<sect2
+ xmlns="http://docbook.org/ns/docbook"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink"
+ version="5.0">
+ <title>Change in URL of internal cf-usb broker endpoint</title>
+ <para>
+  This change is only applicable for upgrades from &cap; 1.2.1 to &cap; 1.3 and
+  upgrades from &cap; 1.3 to &cap; 1.3.1. The URL of the internal cf-usb broker
+  endpoint has changed. Brokers for PostgreSQL and MySQL that use cf-usb will
+  require the following manual fix after upgrading to reconnect with SCF/CAP:
+ </para>
+ <para>
+  For &cap; 1.2.1 to &cap; 1.3 upgrades:
+ </para>
+ <procedure>
+  <step>
+   <para>
+    Get the name of the secret (e.g. <literal>secrets-2.14.5-1</literal>):
+   </para>
+<screen>&prompt.user;kubectl get secret --namespace scf</screen>
+  </step>
+  <step>
+   <para>
+    Get the URL of the <literal>cf-usb</literal> host (e.g.
+    <literal>https://cf-usb.scf.svc.cluster.local:24054</literal>):
+   </para>
+<screen>&prompt.user;cf service-brokers</screen>
+  </step>
+  <step>
+   <para>
+    Get the current <literal>cf-usb</literal> password. Use the name of the
+    secret obtained in the first step:
+   </para>
+<screen>&prompt.user;kubectl get secret --namespace scf <replaceable>secrets-2.14.5-1</replaceable> -o yaml | grep \\scf-usb-password: | cut -d: -f2 | base64 -id</screen>
+  </step>
+  <step>
+   <para>
+    Update the service broker, where <literal>password</literal> is the
+    password from the previous step, and the URL is the result of the second
+    step with the leading <literal>cf-usb</literal> part doubled with a dash
+    separator
+   </para>
+<screen>&prompt.user;cf update-service-broker <replaceable>usb</replaceable> <replaceable>broker-admin</replaceable> <replaceable>password</replaceable> <replaceable>https://cf-usb-cf-usb.scf.svc.cluster.local:24054</replaceable></screen>
+  </step>
+ </procedure>
+ <para>
+  For &cap; 1.3 to &cap; 1.3.1 upgrades:
+ </para>
+ <procedure>
+  <step>
+   <para>
+    Get the name of the secret (e.g. <literal>secrets-2.15.1-1</literal>):
+   </para>
+<screen>&prompt.user;kubectl get secret --namespace scf</screen>
+  </step>
+  <step>
+   <para>
+    Get the URL of the <literal>cf-usb</literal> host (e.g.
+    <literal>https://cf-usb-cf-usb.scf.svc.cluster.local:24054</literal>):
+   </para>
+<screen>&prompt.user;cf service-brokers</screen>
+  </step>
+  <step>
+   <para>
+    Get the current <literal>cf-usb</literal> password. Use the name of the
+    secret obtained in the first step:
+   </para>
+<screen>&prompt.user;kubectl get secret --namespace scf <replaceable>secrets-2.15.1-1</replaceable> -o yaml | grep \\scf-usb-password: | cut -d: -f2 | base64 -id</screen>
+  </step>
+  <step>
+   <para>
+    Update the service broker, where <literal>password</literal> is the
+    password from the previous step, and the URL is the result of the second
+    step with the leading <literal>cf-usb-</literal> part removed:
+   </para>
+<screen>&prompt.user;cf update-service-broker <replaceable>usb</replaceable> <replaceable>broker-admin</replaceable> <replaceable>password</replaceable> <replaceable>https://cf-usb.scf.svc.cluster.local:24054</replaceable></screen>
+  </step>
+ </procedure>
+</sect2>


### PR DESCRIPTION
URL has been fixed in 1.3.1 and no longer requires additional `cf-usb-` prefix in it.

Also broke off content and used xincludes