### PR TITLE
Replace e.g. and i.e. with 'for example' and 'that is' to conform to the

### DIFF
--- a/xml/cap_admin_backup-restore.xml
+++ b/xml/cap_admin_backup-restore.xml
@@ -511,7 +511,7 @@
   <para>
    A backup and restore of an existing SCF deployment's raw data can be used to
    migrate all data to a new SCF deployment. This procedure is applicable to
-   deployments running on any &kube; cluster (e.g. &suse; &caasp;, Amazon EKS,
+   deployments running on any &kube; cluster (for example &suse; &caasp;, Amazon EKS,
    and Azure AKS described in this guide) and can included in your disaster
    recovery solution.
   </para>

--- a/xml/cap_admin_certificates.xml
+++ b/xml/cap_admin_certificates.xml
@@ -248,7 +248,7 @@ cf login</screen>
    file. If rotation of the secrets is required, increment the value of
    <literal>secrets_generation_counter</literal> in the
    <literal>kube:</literal> section of the <filename>values.yaml</filename>
-   configuration file (e.g. the example
+   configuration file (for example the example
    <filename>scf-config-values.yaml</filename> used in this guide) then run
    <command>helm upgrade</command>.
   </para>

--- a/xml/cap_admin_logging.xml
+++ b/xml/cap_admin_logging.xml
@@ -211,7 +211,7 @@ output {
    <literal>LOG_LEVEL</literal> property found in the <literal>env:</literal>
    section. The <literal>LOG_LEVEL</literal> property is mapped to
    component-specific levels. Components have differing technology compositions
-   (e.g. languages, frameworks) and results in each component determining for
+   (for example languages, frameworks) and results in each component determining for
    itself what content to provide at each level, which may vary between
    components.
   </para>

--- a/xml/cap_admin_offline_buildpacks.xml
+++ b/xml/cap_admin_offline_buildpacks.xml
@@ -75,7 +75,7 @@
    <listitem>
     <para>
      <replaceable>org</replaceable> is the Github organization hosting the
-     buildpack repositories, i.e.
+     buildpack repositories, such as
      <link xlink:href="https://github.com/cloudfoundry">"cloudfoundry"</link>
      or <link xlink:href="https://github.com/SUSE">"SUSE"</link>
     </para>
@@ -206,7 +206,7 @@ dotnet-core_buildpack   10         true      false    dotnet-core-buildpack-v2.0
       <listitem>
        <para>
         Using the <command>-b</command> option during <command>cf
-        push</command>. E.g.
+        push</command>, for example:
        </para>
 <screen>&prompt.user;cf push <replaceable>my_application</replaceable> -b <replaceable>my_buildpack</replaceable></screen>
       </listitem>

--- a/xml/cap_admin_upgrade.xml
+++ b/xml/cap_admin_upgrade.xml
@@ -125,7 +125,7 @@ suse/uaa        2.7.0       A Helm chart for SUSE UAA
   <para>
    Just like your initial installation, wait for each command to complete
    before running the next command. Monitor progress with the
-   <command>watch</command> command for each namespace, e.g. <command>watch -c
+   <command>watch</command> command for each namespace, for example <command>watch -c
    'kubectl get pods --namespace uaa'</command>. First upgrade UAA:
   </para>
 

--- a/xml/cap_depl_azure.xml
+++ b/xml/cap_depl_azure.xml
@@ -154,7 +154,7 @@ cap-aks</screen>
     <para>
      Create the AKS managed cluster name. Azure's default is to use the
      resource group name, then prepend it with <literal>MC</literal> and append
-     the location, e.g. <literal>MC_cap-aks_cap-aks_eastus</literal>. This
+     the location, for example <literal>MC_cap-aks_cap-aks_eastus</literal>. This
      example uses the creator's initials for the <literal>AKSNAME</literal>
      environment variable, which will be mapped to the <command>az</command>
      command's <command>--name</command> option. The <command>--name</command>
@@ -208,7 +208,7 @@ cap-aks</screen>
    <step>
     <para>
      Create a unique nodepool name. The default is
-     <literal>aks-nodepool</literal> followed by an auto-generated number, e.g.
+     <literal>aks-nodepool</literal> followed by an auto-generated number, for example
      <literal>aks-nodepool1-39318075-2</literal>. You have the option to change
      <literal>nodepool1</literal> and create your own unique identifier, for
      example, <literal>mypool</literal>:

--- a/xml/cap_depl_eks.xml
+++ b/xml/cap_depl_eks.xml
@@ -661,7 +661,7 @@ secrets:
       the AWS Service Broker, make sure to update the &helm; chart version (the
       version as of this writing is <literal>1.0.0-beta.3</literal>). For the
       broker install, pass in a value indicating the Cluster Service Broker
-      should not be installed (e.g. <command>--set
+      should not be installed (for example <command>--set
       deployClusterServiceBroker=false</command>). Ensure an account and role
       with adequate IAM rights is chosen (see
       <xref linkend="sec.cap.aws-service-broker-prereqs"/>:
@@ -699,7 +699,7 @@ secrets:
      <para>
       Create a service broker in SCF. Note the name of the service broker
       should be the same as the one specified for the <literal>--name</literal>
-      flag in the <command>helm install</command> step (e.g.
+      flag in the <command>helm install</command> step (for example
       <literal>aws-servicebroker</literal>. Note that the username and password
       parameters are only used as dummy values to pass to the
       <command>cf</command> command:

--- a/xml/cap_depl_ha.xml
+++ b/xml/cap_depl_ha.xml
@@ -71,7 +71,7 @@ perl -ne '/^sizing/..0 and do { print $.,":",$_ if /^ [a-z]/ || /high avail|scal
    <para>
     The simplest way to make your &productname; deployment highly available is
     to set <literal>HA</literal> to <literal>true</literal> in your deployment
-    configuration file, e.g. <filename>scf-config-values.yaml</filename>:
+    configuration file, for example <filename>scf-config-values.yaml</filename>:
    </para>
 <screen>
 config:
@@ -108,7 +108,7 @@ config:
    <para>
     The first example is for the UAA namespace,
     <filename>uaa-sizing.yaml</filename>. The values specified are the minimum
-    required for a &ha; deployment (i.e. equivalent to setting
+    required for a &ha; deployment (that is equivalent to setting
     <literal>config.HA</literal> to true):
    </para>
 <screen>
@@ -120,7 +120,7 @@ sizing:
 </screen>
    <para>
     The second example is for SCF, <filename>scf-sizing.yaml</filename>. The
-    values specified are the minimum required for a &ha; deployment (i.e.
+    values specified are the minimum required for a &ha; deployment (that is
     equivalent to setting <literal>config.HA</literal> to true), except for
     <literal>diego-cell</literal> which includes additional instances:
    </para>

--- a/xml/cap_depl_install_caasp.xml
+++ b/xml/cap_depl_install_caasp.xml
@@ -82,7 +82,7 @@
       provides external access to the cluster. Another option is to use DNS
       round-robin to the &kube; workers to provide external access. It is also
       a common practice to create a wildcard DNS entry pointing to the domain,
-      e.g. *.&exampledomain;, so that applications can be deployed without
+      for example *.&exampledomain;, so that applications can be deployed without
       creating DNS entries for each application. This guide does not describe
       how to set up a load balancer or name services, as these depend on
       customer requirements and existing network architectures.

--- a/xml/cap_depl_openstack.xml
+++ b/xml/cap_depl_openstack.xml
@@ -86,7 +86,7 @@
   <para>
    Create an OpenStack network plus a subnet for &caasp; (for example,
    <replaceable>caasp-net</replaceable>), and add a router to the external
-   (e.g. floating) network:
+   (floating) network:
   </para>
 
 <screen>&prompt.user;openstack network create <replaceable>caasp-net</replaceable>

--- a/xml/cap_kube_requirements.xml
+++ b/xml/cap_kube_requirements.xml
@@ -47,7 +47,7 @@
      different storage class in your deployment's
      <filename>values.yaml</filename> file (which is called
      <filename>scf-config-values.yaml</filename> in the examples in this
-     guide), or as a <command>helm</command> command option, e.g.
+     guide), or as a <command>helm</command> command option, for example
      <command>--set kube.storage_class.persistent=my_storage_class</command>.
     </para>
    </listitem>

--- a/xml/cap_overview.xml
+++ b/xml/cap_overview.xml
@@ -204,7 +204,7 @@
    <title>Required Knowledge</title>
    <para>
     Installing and administering &productname; requires knowledge of Linux,
-    &docker;, &kube;, and your &kube; platform (e.g. &suse; &caasp;, AKS, EKS,
+    &docker;, &kube;, and your &kube; platform (for example &suse; &caasp;, AKS, EKS,
     OpenStack). You must plan resource allocation and network architecture by
     taking into account the requirements of your &kube; platform in addition to
     &scf; requirements. &scf; is a discrete component in your cloud stack, but
@@ -725,7 +725,7 @@
        <entry>&cap; components</entry>
        <entry>JSON object and HTTP Status code</entry>
        <entry>TLS certificate on external endpoint</entry>
-       <entry>&cap; Clients interact with the &scf; API (e.g. users deploying apps)</entry>
+       <entry>&cap; Clients interact with the &scf; API (for example users deploying apps)</entry>
       </row>
       <row>
        <entry>5</entry>
@@ -738,7 +738,7 @@
        <entry>&cap; components</entry>
        <entry>A stream of &scf; logs</entry>
        <entry>TLS certificate on external endpoint</entry>
-       <entry>&scf; clients ask for logs (e.g. user looking at application logs or administrator viewing system logs)</entry>
+       <entry>&scf; clients ask for logs (for example user looking at application logs or administrator viewing system logs)</entry>
       </row>
       <row>
        <entry>6</entry>
@@ -751,7 +751,7 @@
        <entry>&cap; components</entry>
        <entry>A duplex connection is created allowing the user to interact with a shell</entry>
        <entry>RSA SSH Key on external endpoint</entry>
-       <entry>&scf; Clients open an SSH connection to an application's container (e.g. users debugging their applications)</entry>
+       <entry>&scf; Clients open an SSH connection to an application's container (for example users debugging their applications)</entry>
       </row>
       <row>
        <entry>7</entry>

--- a/xml/sec_cf_usb_url.xml
+++ b/xml/sec_cf_usb_url.xml
@@ -22,13 +22,13 @@
  <procedure>
   <step>
    <para>
-    Get the name of the secret (e.g. <literal>secrets-2.14.5-1</literal>):
+    Get the name of the secret (for example <literal>secrets-2.14.5-1</literal>):
    </para>
 <screen>&prompt.user;kubectl get secret --namespace scf</screen>
   </step>
   <step>
    <para>
-    Get the URL of the <literal>cf-usb</literal> host (e.g.
+    Get the URL of the <literal>cf-usb</literal> host (for example
     <literal>https://cf-usb.scf.svc.cluster.local:24054</literal>):
    </para>
 <screen>&prompt.user;cf service-brokers</screen>
@@ -56,13 +56,13 @@
  <procedure>
   <step>
    <para>
-    Get the name of the secret (e.g. <literal>secrets-2.15.1-1</literal>):
+    Get the name of the secret (for example <literal>secrets-2.15.1-1</literal>):
    </para>
 <screen>&prompt.user;kubectl get secret --namespace scf</screen>
   </step>
   <step>
    <para>
-    Get the URL of the <literal>cf-usb</literal> host (e.g.
+    Get the URL of the <literal>cf-usb</literal> host (for example
     <literal>https://cf-usb-cf-usb.scf.svc.cluster.local:24054</literal>):
    </para>
 <screen>&prompt.user;cf service-brokers</screen>


### PR DESCRIPTION
documentation style guide