### PR TITLE
Updated Travis files

### DIFF
--- a/.travis-build-docs
+++ b/.travis-build-docs
@@ -1,1 +1,0 @@
-DC-cap-guides

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,6 @@ env:
     - COMMIT_AUTHOR_MAIL: "doc-team@suse.com"
     # If you want to see a list of installed packages in the doc-ci docker container, set to TRUE
     - LIST_PACKAGES=0
-    # List branches that should be published on GitHub pages, omit the maintenance/ prefix
-    - PUBLISH_PRODUCTS="develop"
 
 before_install:
   - echo "TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST" >> env.list
@@ -18,7 +16,6 @@ before_install:
   - echo "SOURCE_BRANCH=$SOURCE_BRANCH" >> env.list
   - echo "TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG" >> env.list
   - echo "LIST_PACKAGES=$LIST_PACKAGES" >> env.list
-  - echo "PUBLISH_PRODUCTS=\"$PUBLISH_PRODUCTS\"" >> env.list
   - echo "ENCRYPTED_PRIVKEY_SECRET=$ENCRYPTED_PRIVKEY_SECRET" >> env.list
   - echo "TRAVIS_COMMIT=$TRAVIS_COMMIT" >> env.list
   - wget https://raw.githubusercontent.com/openSUSE/doc-ci/develop/travis/travis.sh


### PR DESCRIPTION
As per Stefan's email:

```
Everyone working on a repo that is published to susedoc.github.io, note
that Travis will now completely IGNORE the following two items:

* the variable PUBLISH_PRODUCTS in .travis.yml
* the entire .travis-build-docs file

To avoid confusion, please REMOVE BOTH of these items from your repos.


The values that used to be supplied from those two places are now
SUPPLIED BY the CONFIGURATION FILE that was previously only used to
configure the navigation page for susedoc.github.io:

 https://github.com/SUSEdoc/susedoc.github.io/blob/master/index-config.xml

There are no changes in this file -- its syntax is exactly as
previously, now there are slightly higher stakes though.
```