### PR TITLE
AKS service broker: change sample application used

### DIFF
--- a/xml/cap_depl_azure.xml
+++ b/xml/cap_depl_azure.xml
@@ -641,8 +641,9 @@ tcp-router-tcp-router-public                LoadBalancer   10.0.132.203   23.96.
   <title>Configuring and Testing the Native &aks; Service Broker</title>
 
   <para>
-   &ms; &azureks; provides a service broker. This section describes how to use
-   it with your &productname; deployment.
+   &ms; &azureks; provides a service broker called the Open Service Broker for
+   Azure (see <link xlink:href="https://github.com/Azure/open-service-broker-azure"/>.
+   This section describes how to use it with your &productname; deployment.
   </para>
 
   <para>
@@ -693,7 +694,7 @@ tcp-router-tcp-router-public                LoadBalancer   10.0.132.203   23.96.
 </screen>
 
   <para>
-   Set up the service broker with your variables, then create it:
+   Set up the service broker with your variables:
   </para>
 
 <screen>
@@ -709,25 +710,39 @@ tcp-router-tcp-router-public                LoadBalancer   10.0.132.203   23.96.
 --set basicAuth.username=$(tr -dc 'a-zA-Z0-9' &lt; /dev/urandom | head -c 16) \
 --set basicAuth.password=$(tr -dc 'a-zA-Z0-9' &lt; /dev/urandom | head -c 16) \
 --set tls.enabled=false
-
+</screen>
+  <para>
+   Monitor the progress:
+  </para>
+<screen>&prompt.user;watch -c 'kubectl get pods --namespace osba'</screen>
+  <para>
+   When all pods are running, create the service broker in &scf; using the &cfcli;:
+  </para>
+<screen>
 &prompt.user;cf login
 
-&prompt.user;cf create-service-broker azure $(kubectl get deployment osba-open-service-broker-azure \
+&prompt.user;cf create-service-broker <replaceable>azure</replaceable> $(kubectl get deployment osba-open-service-broker-azure \
 --namespace osba -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name == "BASIC_AUTH_USERNAME")].value}') $(kubectl get secret --namespace osba osba-open-service-broker-azure -o jsonpath='{.data.basic-auth-password}' | base64 -d) http://osba-open-service-broker-azure.osba
 </screen>
 
   <para>
-   Register the service broker in &scf;:
+   List the available service plans. For more information about the services
+   supported see
+   <link xlink:href="https://github.com/Azure/open-service-broker-azure#supported-services"/>:
   </para>
-
+<screen>&prompt.user;cf service-access -b <replaceable>azure</replaceable></screen>
+  <para>
+   Use <command>cf enable-service-access</command> to enable access to a service plan. This
+   example enables all <literal>basic</literal> plans:
+  </para>
 <screen>
-&prompt.user;cf service-access -b azure | \
+&prompt.user;cf service-access -b <replaceable>azure</replaceable> | \
 awk '($2 ~ /basic/) { system("cf enable-service-access " $1 " -p " $2)}'
 </screen>
 
   <para>
-   Test your new service broker with an example Rails app. First create a space
-   and org for your test app:
+   Test your new service broker with an example PHP application. First create an
+   organization and space to deploy your test application to:
   </para>
 
 <screen>
@@ -737,11 +752,11 @@ awk '($2 ~ /basic/) { system("cf enable-service-access " $1 " -p " $2)}'
 
 &prompt.user;cf target -o "<replaceable>testorg</replaceable>" -s "<replaceable>scftest</replaceable>"
 
-&prompt.user;cf create-service azure-mysql-5-7 basic <replaceable>scf-rails-example-db</replaceable> \
+&prompt.user;cf create-service azure-mysql-5-7 basic <replaceable>question2answer-db</replaceable> \
 -c "{ \"location\": \"${REGION}\", \"resourceGroup\": \"${SBRGNAME}\", \"firewallRules\": [{\"name\": \
 \"AllowAll\", \"startIPAddress\":\"0.0.0.0\",\"endIPAddress\":\"255.255.255.255\"}]}"
 
-&prompt.user;cf service <replaceable>scf-rails-example-db</replaceable> | grep status
+&prompt.user;cf service <replaceable>question2answer-db</replaceable> | grep status
 </screen>
 
   <para>
@@ -764,45 +779,30 @@ awk '($2 ~ /basic/) { system("cf enable-service-access " $1 " -p " $2)}'
   </para>
 
   <para>
-   Build and push the test Rails app:
+   Build and push the example PHP application:
   </para>
 
 <screen>
-&prompt.user;git clone https://github.com/scf-samples/rails-example
+&prompt.user;git clone https://github.com/scf-samples/question2answer
 
-&prompt.user;cd rails-example
+&prompt.user;cd question2answer
 
 &prompt.user;cf push
 
-&prompt.user;cf ssh scf-rails-example -c "export PATH=/home/vcap/deps/0/bin:/usr/local/bin:/usr/bin:/bin &amp;&amp; \
-export BUNDLE_PATH=/home/vcap/deps/0/vendor_bundle/ruby/2.5.0 &amp;&amp; \
-export BUNDLE_GEMFILE=/home/vcap/app/Gemfile &amp;&amp; cd app &amp;&amp; bundle exec rake db:seed"
-
-&prompt.user;cf service scf-rails-example-db # => bound apps
+&prompt.user;cf service question2answer-db # => bound apps
 </screen>
 
   <para>
-   Test your new service deployment with <command>curl</command>, replacing the
-   example IP address with your own IP address:
+   When the application has finished deploying, use your browser and
+   navigate to the URL specified in the <literal>routes</literal>
+   field displayed at the end of the staging logs. For example, the
+   application route could be
+   <replaceable>question2answer.btat.susecap.net</replaceable>. 
   </para>
-
-<screen>
-&prompt.user;curl -k https://scf-rails-example.<replaceable>&publicip;</replaceable>
-</screen>
 
   <para>
-   A successful deployment returns output like this abbreviated example:
+   Press the button to prepare the database. When the database is ready,
+   further verify by creating an initial user and posting some test questions.
   </para>
-
-<screen>
- &lt;h1>Hello from Rails on SCF!&lt;/h1>
-2018-12-19T12:53:30+00:00
-
-&lt;ul>
-  &lt;li>#1: Drink coffee&lt;/li>
-  &lt;li>#2: Go to work&lt;/li>
-  &lt;li>#3: Have some rest&lt;/li>
-&lt;/ul>
-</screen>
  </sect1>
 </chapter>


### PR DESCRIPTION
- was: rails-example, now: question2answer (PHP)
- easier to recognize a database is used

Resolves #306 

[book.cap.guides_color_en.pdf](https://github.com/SUSE/doc-cap/files/2994343/book.cap.guides_color_en.pdf)
