### PR TITLE
Specify vm-set-type AvailabilitySet

### DIFF
--- a/xml/cap_depl_aks.xml
+++ b/xml/cap_depl_aks.xml
@@ -301,7 +301,7 @@ export NODEPOOL_NAME="mypool"
  --node-count $NODE_COUNT --admin-username $ADMIN_USERNAME \
  --ssh-key-value $SSH_KEY_VALUE --node-vm-size $NODE_VM_SIZE \
  --node-osdisk-size=&node-size; --nodepool-name $NODEPOOL_NAME \
- --kubernetes-version <replaceable>&aksnodeversion;</replaceable>
+ --vm-set-type AvailabilitySet --kubernetes-version <replaceable>&aksnodeversion;</replaceable>
 </screen>
 
   <note>


### PR DESCRIPTION
Some commands in the swapaccounting script fails as some VMs default
to the VirtualMachineScaleSets type for certain region + kube version
combinations

CAP-938