### PR TITLE
Kube 1.16 is compatible now

### DIFF
--- a/xml/cap_kube_requirements.xml
+++ b/xml/cap_kube_requirements.xml
@@ -26,7 +26,7 @@
   <itemizedlist>
    <listitem>
     <para>
-     &kube; API version of at least 1.10, but less than 1.16
+     &kube; API version of at least 1.10
     </para>
    </listitem>
    <listitem>


### PR DESCRIPTION
Testing by Troy has shown that 1.16 is compatible