### PR TITLE
Clarify difference between ROOTFS_TRUSTED_CERTS and TRUSTED_CERTS

### DIFF
--- a/xml/cap_admin_certificates.xml
+++ b/xml/cap_admin_certificates.xml
@@ -366,9 +366,9 @@
      No difference between applications from buildpacks and from &docker; images.
    </para>
    <para>
-     The ROOT_TRUSTED_CERTS parameter contains a list of CA certificates which
+     <literal>The ROOT_TRUSTED_CERTS</literal> parameter contains a list of CA certificates which
      are available in application instance containers through the general OS trust store.
-     Only applications based on buildpack (and a rootfs) receive the information.
+     Only applications based on buildpacks (and a rootfs) receive the information.
    </para>
    <para>
      Summary
@@ -382,7 +382,7 @@
       <listitem>
         <para>
           <literal>ROOTFS_TRUSTED_CERTS</literal> only applies to applications based
-          on build packs and rootfs and are automatically available through
+          on buildpacks and rootfs and are automatically available through
           the OS trust store.
         </para>
        </listitem>

--- a/xml/cap_admin_certificates.xml
+++ b/xml/cap_admin_certificates.xml
@@ -362,7 +362,7 @@
      available in application instance containers as files in the directory
      <filename>/etc/cf-system-certificates</filename> and the general trust store
      (Only cflinuxfs3).
-     The enviromental value <literal>CF_SYSTEM_CERT_PATH</literal> holds the first path.
+     The environment variable <literal>CF_SYSTEM_CERT_PATH</literal> holds the first path.
      No difference between applications from buildpacks and from &docker; images.
    </para>
    <para>
@@ -390,7 +390,7 @@
          <para>
            <literal>TRUSTED_CERTS</literal> applies to all applications, based on both
            buildpacks and &docker; images. Not automatically available. Applications
-           have to use the enviromental value <literal>CF_SYSTEM_CERT_PATH</literal>
+           have to use the environment variable <literal>CF_SYSTEM_CERT_PATH</literal>
            and add the certificates themselves.
          </para>
         </listitem>

--- a/xml/cap_admin_certificates.xml
+++ b/xml/cap_admin_certificates.xml
@@ -355,4 +355,45 @@
 --version &latestscfchart;
 </screen>
  </sect1>
+ <sect1 xml:id="sec-cap-trusted-certs">
+   <title>Difference between TRUSTED_CERTS and ROOTFS_TRUSTED_CERTS</title>
+   <para>
+     The <literal>TRUSTED_CERTS</literal> parameter contains a list of CA certificates which become
+     available in application instance containers as files in the directory
+     <filename>/etc/cf-system-certificates</filename> and the general trust store
+     (Only cflinuxfs3).
+     The enviromental value <literal>CF_SYSTEM_CERT_PATH</literal> holds the first path.
+     No difference between applications from buildpacks and from &docker; images.
+   </para>
+   <para>
+     The ROOT_TRUSTED_CERTS parameter contains a list of CA certificates which
+     are available in application instance containers through the general OS trust store.
+     Only applications based on buildpack (and a rootfs) receive the information.
+   </para>
+   <para>
+     Summary
+   </para>
+   <itemizedlist>
+     <listitem>
+       <para>
+         Both contain additional CA certificates for applications.
+       </para>
+      </listitem>
+      <listitem>
+        <para>
+          <literal>ROOTFS_TRUSTED_CERTS</literal> only applies to applications based
+          on build packs and rootfs and are automatically available through
+          the OS trust store.
+        </para>
+       </listitem>
+       <listitem>
+         <para>
+           <literal>TRUSTED_CERTS</literal> applies to all applications, based on both
+           buildpacks and &docker; images. Not automatically available. Applications
+           have to use the enviromental value <literal>CF_SYSTEM_CERT_PATH</literal>
+           and add the certificates themselves.
+         </para>
+        </listitem>
+   </itemizedlist>
+ </sect1>
 </chapter>


### PR DESCRIPTION
Closes #465.

Right now it's kind of awkwardly tacked onto the end of the certificate chapter as proposed in #465 which might need to be changed.