### PR TITLE
Example should refer to only config file and not CLI too

### DIFF
--- a/xml/cap_depl_ha.xml
+++ b/xml/cap_depl_ha.xml
@@ -102,13 +102,14 @@ config:
   HA: true
 </screen>
    <para>
-    Or, you may pass it as a command line option when you are deploying with
-    &helm;, for example:
+    Use <command>helm install</command> to deploy or
+    <command>helm upgrade</command> to apply the change to an existing
+    deployment.
    </para>
 <screen>&prompt.user;helm install suse/uaa \
- --name susecf-uaa \
- --namespace uaa \
- --values scf-config-values.yaml
+--name susecf-uaa \
+--namespace uaa \
+--values scf-config-values.yaml
 </screen>
    <para>
     When <literal>config.HA</literal> is set to <literal>true</literal>,


### PR DESCRIPTION
Closes #665 

The example and corresponding description were updated in https://github.com/SUSE/doc-cap/commit/9aa2c1cd4c0e40b43823f313857098162460b122 to only mention using the config file, but looks like it was overwritten during subsequent merges resulting in an example that does not match the description. This PR adds the change back.