### PR TITLE
Use available SVGS

### DIFF
--- a/xml/cap_overview.xml
+++ b/xml/cap_overview.xml
@@ -301,10 +301,10 @@
    <title>Minimal Example Production Deployment</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="cap-arch-prod.png" format="PNG" width="90%"/>
+     <imagedata fileref="cap-arch-prod.svg" format="SVG" width="90%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="cap-arch-prod.png"/>
+     <imagedata fileref="cap-arch-prod.svg"/>
     </imageobject>
     <textobject role="description"><phrase>network architecture of minimal production setup</phrase>
     </textobject>
@@ -364,10 +364,10 @@
    <title>Cloud Platform Comparisons</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="cloud-101.png" format="PNG" width="75%"/>
+     <imagedata fileref="cloud-101.svg" format="SVG" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="cloud-101.png"/>
+     <imagedata fileref="cloud-101.svg"/>
     </imageobject>
     <textobject role="description"><phrase>Comparison of cloud platforms.</phrase>
     </textobject>
@@ -383,10 +383,10 @@
    <title>Containerized Platforms</title>
    <mediaobject>
     <imageobject role="fo">
-     <imagedata fileref="cap-containerized.png" format="PNG" width="75%"/>
+     <imagedata fileref="cap-containerized.svg" format="SVG" width="75%"/>
     </imageobject>
     <imageobject role="html">
-     <imagedata fileref="cap-containerized.png"/>
+     <imagedata fileref="cap-containerized.svg"/>
     </imageobject>
     <textobject role="description"><phrase>&suse; &caasp; and &productname; containerize the
       platform itself.</phrase>
@@ -493,10 +493,10 @@
     <title>&scf; Containers, Grouped by Function</title>
     <mediaobject>
      <imageobject role="fo">
-      <imagedata fileref="cap-containers.png" format="PNG" width="75%"/>
+      <imagedata fileref="cap-containers.svg" format="SVG" width="75%"/>
      </imageobject>
      <imageobject role="html">
-      <imagedata fileref="cap-containers.png"/>
+      <imagedata fileref="cap-containers.svg" format="SVG"/>
      </imageobject>
      <textobject role="description"><phrase>&scf;'s containers, grouped
             by functionality.</phrase>


### PR DESCRIPTION
The doc itself was never updated to point to the SVGs that were converted form PNG. This updates to use those converted images.

Note `cap-kube.svg` was not updated. When I change the fileref to the SVG version, building the PDF gives an error. Omitting that for now and will investigate at a later time why that particular image has issues.