### PR TITLE
Add and use new entities for sections in deployment platform chapter

### DIFF
--- a/xml/cap_admin_app_autoscaler.xml
+++ b/xml/cap_admin_app_autoscaler.xml
@@ -67,7 +67,7 @@
 <screen>&prompt.user;helm upgrade <replaceable>susecf-scf</replaceable> suse/cf \
 --values scf-config-values.yaml \
 --set "enable.autoscaler=true" \
---version &cf_chart;
+--version &kubecf_chart;
 </screen>
 
   <para>
@@ -78,7 +78,7 @@
 <screen>&prompt.user;helm upgrade <replaceable>susecf-scf</replaceable> suse/cf \
 --values scf-config-values.yaml \
 --set "enable.autoscaler=false" \
---version &cf_chart;
+--version &kubecf_chart;
 </screen>
 
  </sect1>

--- a/xml/cap_admin_app_domains.xml
+++ b/xml/cap_admin_app_domains.xml
@@ -68,7 +68,7 @@
   </para>
 <screen>&prompt.user;helm upgrade <replaceable>susecf-scf</replaceable> suse/cf \
 --values scf-config-values.yaml \
---version &cf_chart;
+--version &kubecf_chart;
 </screen>
 
   &scf-deploy-complete;

--- a/xml/cap_admin_ccdb_key_rotation.xml
+++ b/xml/cap_admin_ccdb_key_rotation.xml
@@ -52,7 +52,7 @@ secrets:
    </para>
 <screen>&prompt.user;helm upgrade susecf-scf suse/cf \
 --values scf-config-values.yaml \
---version &cf_chart;
+--version &kubecf_chart;
    </screen>
   </step>
   <step>

--- a/xml/cap_admin_certificates.xml
+++ b/xml/cap_admin_certificates.xml
@@ -185,7 +185,7 @@
     </para>
 <screen>&prompt.user;helm upgrade <replaceable>susecf-scf</replaceable> suse/cf \
 --values scf-config-values.yaml \
---version &cf_chart;
+--version &kubecf_chart;
 </screen>
    </step>
    <step>
@@ -240,7 +240,7 @@
 
 <screen>&prompt.user;helm upgrade <replaceable>susecf-scf</replaceable> suse/cf \
 --values scf-config-values.yaml \
---version &cf_chart;
+--version &kubecf_chart;
 </screen>
  </sect1>
  <sect1 xml:id="sec-cap-trusted-certs">

--- a/xml/cap_admin_credhub.xml
+++ b/xml/cap_admin_credhub.xml
@@ -64,7 +64,7 @@
 <screen>&prompt.user;helm upgrade <replaceable>susecf-scf</replaceable> suse/cf \
 --values scf-config-values.yaml \
 --set "enable.credhub=true" \
---version &cf_chart;
+--version &kubecf_chart;
 </screen>
 
  <warning>
@@ -87,7 +87,7 @@
 <screen>&prompt.user;helm upgrade <replaceable>susecf-scf</replaceable> suse/cf \
 --values scf-config-values.yaml \
 --set "enable.credhub=false" \
---version &cf_chart;
+--version &kubecf_chart;
 </screen>
  </sect1>
  <sect1 xml:id="sec-cap-credhub-upgrade-considerations">

--- a/xml/cap_admin_nproc_limits.xml
+++ b/xml/cap_admin_nproc_limits.xml
@@ -140,7 +140,7 @@
      </para>
 <screen>&prompt.user;helm upgrade susecf-scf suse/cf \
 --values scf-config-values.yaml \
---version &cf_chart;
+--version &kubecf_chart;
 </screen>
     </step>
     <step>

--- a/xml/cap_depl_aks.xml
+++ b/xml/cap_depl_aks.xml
@@ -334,74 +334,13 @@ export NODEPOOL_NAME="mypool"
   </para>
  </sect1>
 
- <!-- sect1 for helm client installation -->
- &install-helm;
+  <!-- Entry defined in xml/repeated-content-decl.ent -->
+  &install-helm;
 
  <sect1 xml:id="sec-cap-aks-storage">
-  <title>Default Storage Class</title>
-  <para>
-   This example creates a <literal>managed-premium</literal> (see
-   <link xlink:href="https://docs.microsoft.com/en-us/azure/aks/azure-disks-dynamic-pv"/>)
-   storage class for your cluster using the manifest defined in
-   <filename>storage-class.yaml</filename> below:
-  </para>
-
-<screen>---
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
-  labels:
-    kubernetes.io/cluster-service: "true"
-  name: persistent
-parameters:
-  kind: Managed
-  storageaccounttype: Premium_LRS
-provisioner: kubernetes.io/azure-disk
-reclaimPolicy: Delete
-allowVolumeExpansion: true
-</screen>
-
-  <para>
-   Then apply the new storage class configuration with this command:
-  </para>
-
-<screen>&prompt.user;kubectl create --filename storage-class.yaml</screen>
-  <para>
-   Specify the newly created created storage class, called <literal>persistent</literal>,
-   as the value for <literal>kube.storage_class.persistent</literal> in your
-   deployment configuration file, like this example:
-  </para>
-
-<screen>kube:
-  storage_class:
-    persistent: "persistent"
-    shared: "persistent"
-</screen>
-  <para>
-   See <xref linkend="sec-cap-aks-config"/> for a complete example deployment
-   configuration file, <filename>scf-config-values.yaml</filename>.
-  </para>
+  &storage-class;
  </sect1>
 
- <sect1 xml:id="sec-cap-aks-dns">
-  <title>DNS Configuration</title>
-
-  <para>
-   This section provides an overview of the domain and sub-domains that require
-   A records to be set up for. The process is described in more detail in the
-   deployment section.
-  </para>
-
-  <para>
-   The following table lists the required domain and sub-domains, using
-   <literal>example.com</literal> as the example domain:
-  </para>
-
-&dns-tables;
-
- </sect1>
  <sect1 xml:id="sec-cap-aks-config">
   <title>Deployment Configuration</title>
   <para>
@@ -422,6 +361,30 @@ allowVolumeExpansion: true
   &config-value-usage;
 
  </sect1>
+
+ <!-- Begin optional features -->
+
+ <sect1 xml:id="sec-cap-aks-certificates">
+  <!-- Entry defined in xml/repeated-content-decl.ent -->
+  &certificates;
+ </sect1>
+
+ <sect1 xml:id="sec-cap-aks-ingress">
+  <!-- Entry defined in xml/repeated-content-decl.ent -->
+  &ingress-controller;
+ </sect1>
+
+ <sect1 xml:id="sec-cap-aks-high-availability">
+  <!-- Entry defined in xml/repeated-content-decl.ent -->
+  &high-availability;
+ </sect1>
+
+ <sect1 xml:id="sec-cap-aks-external-database">
+  <!-- Entry defined in xml/repeated-content-decl.ent -->
+  &external-database;
+ </sect1>
+
+ <!-- End optional features -->
 
  <sect1 xml:id="sec-cap-addrepo-aks">
   <title>Add the &kube; Charts Repository</title>
@@ -743,8 +706,17 @@ awk '($2 ~ /basic/) { system("cf enable-service-access " $1 " -p " $2)}'
   </para>
  </sect1>
 
+ <!-- Begin optional features -->
+
+ <sect1 xml:id="sec-cap-aks-ldap">
+  <!-- Entry defined in xml/repeated-content-decl.ent -->
+  &ldap;
+ </sect1>
+
+ <!-- End optional features -->
+
  <!-- sect1 for PV resizing -->
- &resize-persistent-volume;
+ <!-- &resize-persistent-volume; -->
 
  <sect1 xml:id="sec-cap-aks-add-capacity">
   <title>Expanding Capacity of a &cap; Deployment on &aks;</title>
@@ -809,7 +781,7 @@ awk '($2 ~ /basic/) { system("cf enable-service-access " $1 " -p " $2)}'
     </para>
 <screen>&prompt.user;helm upgrade susecf-scf suse/cf \
 --values scf-config-values.yaml \
---version &cf_chart;
+--version &kubecf_chart;
 </screen>
    </step>
    <step>

--- a/xml/cap_depl_caasp.xml
+++ b/xml/cap_depl_caasp.xml
@@ -28,7 +28,7 @@
   easy to operate. As a result, enterprises that use &caasp; can reduce
   application delivery cycle times and improve business agility. This chapter
   describes the steps to prepare a &productname; deployment on &caasp;. See
-  <link xlink:href="https://documentation.suse.com/suse-caasp/4.1/"/>              
+  <link xlink:href="https://documentation.suse.com/suse-caasp/4.1/"/>
   for more information on &caasp;.
  </para>
 
@@ -182,7 +182,7 @@
     <para>
      At the cluster initialization step, <emphasis role="bold">do not</emphasis>
      use the <literal>--strict-capability-defaults</literal> option when running
-    </para> 
+    </para>
 <screen>&prompt.user;skuba cluster init</screen>
     <para>
      This ensures the presence of extra CRI-O capabilities compatible with
@@ -228,23 +228,7 @@
   </itemizedlist>
  </sect1>
 
- <sect1 xml:id="sec-cap-caasp-tiller">
-  <title>Installing &helm; Client</title>
-
-  <para>
-   &helm; is a &kube; package manager. The &helm; client,
-   <literal>helm</literal>, is required in order to install and manage &cap;. It
-   can be installed on your management workstation, which is part of the &caasp;
-   package repository, by running
-  </para>
-<screen>&prompt.user;sudo zypper install helm</screen>
-  <para>
-   Alternatively, refer to the upstream documentation at
-   <link xlink:href="https://helm.sh/docs/intro/install/"/>. The examples in
-   this guide are based on &helm; 3. For more information, refer to the
-   documentation at <link xlink:href="https://helm.sh/docs/"/>.
-  </para>
- </sect1>
+  &install-helm;
 
  <sect1 xml:id="sec-cap-caasp-storage">
   <title>Storage Class</title>
@@ -299,10 +283,10 @@ sed's/"namespace": "default"/"namespace": "scf"/' | kubectl create --filename -
    <filename>scf-config-values.yaml</filename> in this guide, provides an
    example of a &productname; configuration.
   </para>
-  <para> 
+  <para>
    Ensure <literal>DOMAIN</literal> maps to the load balancer configured for
    your &caasp; cluster (see
-   <link xlink:href="https://documentation.suse.com/suse-caasp/4.1/single-html/caasp-deployment/#loadbalancer"/>). 
+   <link xlink:href="https://documentation.suse.com/suse-caasp/4.1/single-html/caasp-deployment/#loadbalancer"/>).
   </para>
 
   &supported-domains;
@@ -315,9 +299,33 @@ sed's/"namespace": "default"/"namespace": "scf"/' | kubectl create --filename -
 </screen>
 
   <!-- Explains usage of some Helm values used in the example/minimal values.yaml-->
-  &config-value-usage;                                                          
-                                                                                
-</sect1>
+  &config-value-usage;
+
+ </sect1>
+
+ <!-- Begin optional features -->
+
+ <sect1 xml:id="sec-cap-caasp-certificates">
+  <!-- Entry defined in xml/repeated-content-decl.ent -->
+  &certificates;
+ </sect1>
+
+ <sect1 xml:id="sec-cap-caasp-ingress">
+  <!-- Entry defined in xml/repeated-content-decl.ent -->
+  &ingress-controller;
+ </sect1>
+
+ <sect1 xml:id="sec-cap-caasp-high-availability">
+  <!-- Entry defined in xml/repeated-content-decl.ent -->
+  &high-availability;
+ </sect1>
+
+ <sect1 xml:id="sec-cap-caasp-external-database">
+  <!-- Entry defined in xml/repeated-content-decl.ent -->
+  &external-database;
+ </sect1>
+
+ <!-- End optional features -->
 
  <sect1 xml:id="sec-cap-addrepo-caasp">
   <title>Add the &kube; Charts Repository</title>
@@ -350,7 +358,7 @@ suse       https://kubernetes-charts.suse.com/
  <sect1 xml:id="sec-cap-cap-on-caasp">
   <title>Deploying &productname;</title>
 
-  <sect2 xml:id="sec-cap-caasp-deploy-scf">                                       
+  <sect2 xml:id="sec-cap-caasp-deploy-scf">
    <title>Deploy <literal>scf</literal></title>
    <para>
     Use &helm; to deploy <literal>scf</literal>:
@@ -361,7 +369,7 @@ suse       https://kubernetes-charts.suse.com/
 --namespace <replaceable>scf</replaceable> \
 --values scf-config-values.yaml
 </screen>
-   &scf-deploy-complete; 
+   &scf-deploy-complete;
 
    <para>
     When the deployment completes, use the &cf; command line interface to log in
@@ -369,6 +377,13 @@ suse       https://kubernetes-charts.suse.com/
     <xref linkend="sec-cap-cf-cli"/>)
    </para>
   </sect2>
+ </sect1>
+
+ <!-- Begin optional features -->
+
+ <sect1 xml:id="sec-cap-caasp-ldap">
+  <!-- Entry defined in xml/repeated-content-decl.ent -->
+  &ldap;
  </sect1>
 
  <sect1 xml:id="sec-cap-caasp-add-capacity">
@@ -416,7 +431,7 @@ suse       https://kubernetes-charts.suse.com/
     </para>
 <screen>&prompt.user;helm upgrade susecf-scf suse/cf \
 --values scf-config-values.yaml \
---version &cf_chart;
+--version &kubecf_chart;
 </screen>
    </step>
    <step>

--- a/xml/cap_depl_eks.xml
+++ b/xml/cap_depl_eks.xml
@@ -234,8 +234,8 @@
   </sect2>
  </sect1>
 
- <!-- sect1 for helm client installation -->
- &install-helm;
+ <!-- Entry defined in xml/repeated-content-decl.ent -->
+  &install-helm;
 
  <sect1 xml:id="sec-cap-eks-storage-class">
   <title>Default Storage Class</title>
@@ -299,6 +299,31 @@ allowVolumeExpansion: true
   <!-- Explains usage of some Helm values used in the example/minimal values.yaml-->
   &config-value-usage;
  </sect1>
+
+ <!-- Begin optional features -->
+
+ <sect1 xml:id="sec-cap-eks-certificates">
+  <!-- Entry defined in xml/repeated-content-decl.ent -->
+  &certificates;
+ </sect1>
+
+ <sect1 xml:id="sec-cap-eks-ingress">
+  <!-- Entry defined in xml/repeated-content-decl.ent -->
+  &ingress-controller;
+ </sect1>
+
+ <sect1 xml:id="sec-cap-eks-high-availability">
+  <!-- Entry defined in xml/repeated-content-decl.ent -->
+  &high-availability;
+ </sect1>
+
+ <sect1 xml:id="sec-cap-eks-external-database">
+  <!-- Entry defined in xml/repeated-content-decl.ent -->
+  &external-database;
+ </sect1>
+
+ <!-- End optional features -->
+
  <sect1 xml:id="sec-cap-addrepo-eks">
   <title>Add the &kube; Charts Repository</title>
 
@@ -382,7 +407,7 @@ suse            https://kubernetes-charts.suse.com/</screen>
    load balancer name will be the string preceding the first
    <literal>-</literal> character.
   </para>
- 
+
 <screen>&prompt.user;kubectl get service -n scf tcp-router-tcp-router-public</screen>
 
   <para>
@@ -548,7 +573,7 @@ suse            https://kubernetes-charts.suse.com/</screen>
       <xref linkend="sec-cap-aws-service-broker-prereqs"/>:
      </para>
 <screen>&prompt.user;kubectl create namespace <replaceable>$BROKER_NAMESPACE</replaceable>
-	
+
 &prompt.user;helm install <replaceable>aws-servicebroker</replaceable> aws-sb/aws-servicebroker \
 --namespace <replaceable>$BROKER_NAMESPACE</replaceable> \
 --version 1.0.1 \
@@ -684,6 +709,15 @@ suse            https://kubernetes-charts.suse.com/</screen>
   </sect2>
  </sect1>
 
+ <!-- Begin optional features -->
+
+ <sect1 xml:id="sec-cap-eks-ldap">
+  <!-- Entry defined in xml/repeated-content-decl.ent -->
+  &ldap;
+ </sect1>
+
+ <!-- End optional features -->
+
  <!-- sect1 for PV resizing -->
- &resize-persistent-volume;
+ <!-- &resize-persistent-volume; -->
 </chapter>

--- a/xml/cap_depl_gke.xml
+++ b/xml/cap_depl_gke.xml
@@ -216,67 +216,13 @@
 
  </sect1>
 
- <!-- sect1 for helm client installation -->
- &install-helm;
+  <!-- Entry defined in xml/repeated-content-decl.ent -->
+  &install-helm;
 
  <sect1 xml:id="sec-cap-gke-storage">
-  <title>Default Storage Class</title>
-  <para>
-   This example creates a <literal>pd-ssd</literal>
-   storage class for your cluster.  Create a file named
-   <filename>storage-class.yaml</filename> with the following:
-  </para>
-<screen>---
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  annotations:
-    storageclass.kubernetes.io/is-default-class: "true"
-  labels:
-    addonmanager.kubernetes.io/mode: EnsureExists
-    kubernetes.io/cluster-service: "true"
-  name: persistent
-parameters:
-  type: pd-ssd
-provisioner: kubernetes.io/gce-pd
-reclaimPolicy: Delete
-allowVolumeExpansion: true
-</screen>
-  <para>
-   Create the new storage class using the manifest defined:
-  </para>
-<screen>&prompt.user;kubectl create --filename <replaceable>storage-class.yaml</replaceable></screen>
-  <para>
-   Specify the newly created created storage class, called <literal>persistent</literal>,
-   as the value for <literal>kube.storage_class.persistent</literal> in your
-   deployment configuration file, like this example:
-  </para>
-<screen>kube:
-  storage_class:
-    persistent: "persistent"
-</screen>
-  <para>
-   See <xref linkend="sec-cap-gke-config"/> for a complete example deployment
-   configuration file, <filename>scf-config-values.yaml</filename>.
-  </para>
+  &storage-class;
  </sect1>
 
- <sect1 xml:id="sec-cap-gke-dns">
-  <title>DNS Configuration</title>
-
-  <para>
-   This section provides an overview of the domain and sub-domains that require
-   A records to be set up for. The process is described in more detail in the
-   deployment section.
-  </para>
-
-  <para>
-   The following table lists the required domain and sub-domains, using
-   <literal>example.com</literal> as the example domain:
-  </para>
-
-&dns-tables;
- </sect1>
  <sect1 xml:id="sec-cap-gke-config">
   <title>Deployment Configuration</title>
   <para>
@@ -296,7 +242,31 @@ allowVolumeExpansion: true
   <!-- Explains usage of some Helm values used in the example/minimal values.yaml-->
   &config-value-usage;
 
-</sect1>
+ </sect1>
+
+ <!-- Begin optional features -->
+
+ <sect1 xml:id="sec-cap-gke-certificates">
+  <!-- Entry defined in xml/repeated-content-decl.ent -->
+  &certificates;
+ </sect1>
+
+ <sect1 xml:id="sec-cap-gke-ingress">
+  <!-- Entry defined in xml/repeated-content-decl.ent -->
+  &ingress-controller;
+ </sect1>
+
+ <sect1 xml:id="sec-cap-gke-high-availability">
+  <!-- Entry defined in xml/repeated-content-decl.ent -->
+  &high-availability;
+ </sect1>
+
+ <sect1 xml:id="sec-cap-gke-external-database">
+  <!-- Entry defined in xml/repeated-content-decl.ent -->
+  &external-database;
+ </sect1>
+
+ <!-- End optional features -->
 
  <sect1 xml:id="sec-cap-addrepo-gke">
   <title>Add the &kube; charts repository</title>
@@ -333,11 +303,13 @@ suse       https://kubernetes-charts.suse.com/
    configure your DNS records.
   </para>
 
-  <!-- TODO-CAP2 -->
   <sect2 xml:id="sec-cap-gke-deploy-operator">
-   <title>Deploy <literal>operator</literal></title>
+   &deploy-operator;
   </sect2>
 
+  <sect2 xml:id="kubecf">
+&deploy-kubecf;
+  </sect2>
   <sect2 xml:id="sec-cap-gke-deploy-scf">
    <title>Deploy <literal>scf</literal></title>
    <para>
@@ -991,8 +963,17 @@ applications:
   </sect2>
  </sect1>
 
+ <!-- Begin optional features -->
+
+ <sect1 xml:id="sec-cap-gke-ldap">
+  <!-- Entry defined in xml/repeated-content-decl.ent -->
+  &ldap;
+ </sect1>
+
+ <!-- End optional features -->
+
  <!-- sect1 for PV resizing -->
- &resize-persistent-volume;
+ <!-- &resize-persistent-volume; -->
 
  <sect1 xml:id="sec-cap-gke-add-capacity">
   <title>Expanding Capacity of a &cap; Deployment on &gke;</title>
@@ -1050,7 +1031,7 @@ applications:
     </para>
 <screen>&prompt.user;helm upgrade susecf-scf suse/cf \
 --values scf-config-values.yaml \
---version &cf_chart;
+--version &kubecf_chart;
 </screen>
    </step>
    <step>

--- a/xml/cap_depl_ingress.xml
+++ b/xml/cap_depl_ingress.xml
@@ -275,7 +275,7 @@ ingress:
     </para>
 <screen>&prompt.user;helm upgrade susecf-scf suse/cf \
 --values scf-config-values.yaml --set "secrets.UAA_CA_CERT=${INGRESS_CA_CERT}" \
---version &cf_chart;
+--version &kubecf_chart;
 </screen>
    </step>
    <step>

--- a/xml/cap_overview.xml
+++ b/xml/cap_overview.xml
@@ -24,62 +24,41 @@
   <itemizedlist>
    <listitem>
     <para>
-     &scf; has been updated to version &cf_chart;:
+     &kubecf; has been updated to version &kubecf_chart;:
     </para>
     <itemizedlist>
      <listitem>
       <para>
-       cf-deployment has been updated to 12.17
-      </para>
-     </listitem>
-     <listitem>
-      <para>
-       Optimized startup time for various roles
-      </para>
-     </listitem>
-     <listitem>
-      <para>
-       Added/fixed podAntiAffinity rules for various roles
+	TODO-CAP2 ITEM 1
       </para>
      </listitem>
     </itemizedlist>
    </listitem>
    <listitem>
     <para>
-     Stratos Console has been updated to version 2.7.0:
+     Stratos Console has been updated to version &stratos_chart;:
     </para>
     <itemizedlist>
      <listitem>
       <para>
-       Improvements to the &kube; Dashboard integration (improved configuration
-       and reliability)
+	TODO-CAP2 ITEM 1
       </para>
      </listitem>
      <listitem>
       <para>
-       Improved support for synchronous creation of service instances
-      </para>
-     </listitem>
-     <listitem>
-      <para>
-       Branding updated to "&suse; Stratos Console"
-      </para>
-     </listitem>
-     <listitem>
-      <para>
-       For a full list of features and fixes see <link xlink:href="https://github.com/SUSE/stratos/blob/v2-master/CHANGELOG.md#270"/>
+       For a full list of features and fixes see <link xlink:href="https://github.com/SUSE/stratos/blob/v2-master/CHANGELOG.md#300"/>
       </para>
      </listitem>
     </itemizedlist>
    </listitem>
    <listitem>
     <para>
-     Stratos Metrics has been updated to version 1.1.2:
+     Stratos Metrics has been updated to version &metrics_chart;:
     </para>
     <itemizedlist>
      <listitem>
       <para>
-       Added support for &caasp; V4.1 and &kube; 1.16+ environments
+	TODO-CAP2 ITEM 1
       </para>
      </listitem>
      <listitem>
@@ -93,7 +72,7 @@
   </itemizedlist>
 
   <para>
-   See all product manuals for &productname; 1.x at
+   See all product manuals for &productname; 2.x at
    <link xlink:href="https://documentation.suse.com/suse-cap/1/">&productname; 1</link>.
   </para>
 

--- a/xml/cap_troubleshooting.xml
+++ b/xml/cap_troubleshooting.xml
@@ -116,8 +116,8 @@ routing-api-0            0/1   Running   0         16h</screen>
 
 <screen>&prompt.user;helm list
 NAME            REVISION  UPDATED                  STATUS    CHART           NAMESPACE
-<replaceable>susecf-console</replaceable>  1         Tue Aug 14 11:53:28 2018 DEPLOYED  console-&stratos_chart;   stratos
-<replaceable>susecf-scf</replaceable>      1         Tue Aug 14 10:58:16 2018 DEPLOYED  cf-&cf_chart;       scf
+<replaceable>susecf-console</replaceable>  1         Tue Aug 14 11:53:28 2018 DEPLOYED  &stratos_chart;   stratos
+<replaceable>susecf-scf</replaceable>      1         Tue Aug 14 10:58:16 2018 DEPLOYED  &kubecf_chart;       scf
 </screen>
 
   <para>

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -7,9 +7,11 @@
 <!ENTITY productnumber  "2.0">
 <!ENTITY github.url     "https://github.com/SUSE/doc-cap">
 <!ENTITY cap            "Cloud Application Platform">
+<!ENTITY kubecf         "KubeCF">
+<!ENTITY operator       "quarks-operator">
 <!ENTITY kernel_version "3.19">
 <!ENTITY operator_chart "TODO">
-<!ENTITY cf_chart "TODO">
+<!ENTITY kubecf_chart "TODO">
 <!ENTITY stratos_chart "3.0.0">
 <!ENTITY metrics_chart "1.1.2">
 <!ENTITY minibroker_chart "0.3.1">

--- a/xml/repeated-content-decl.ent
+++ b/xml/repeated-content-decl.ent
@@ -250,7 +250,7 @@ Before you start deploying &productname;, review the following documents:
     <tbody>
      <row>
       <entry>&productnumber; (current release)</entry>
-      <entry>&cf_chart;</entry>
+      <entry>&kubecf_chart;</entry>
       <entry>&stratos_chart;</entry>
       <entry>&metrics_chart;</entry>
       <!-- cf-deployment 12.17: 2.144.0, cf api result: -->
@@ -505,7 +505,7 @@ Before you start deploying &productname;, review the following documents:
 <!ENTITY helm-search-suse
 '<screen xmlns="http://docbook.org/ns/docbook">&prompt.user;helm search suse
 NAME                            CHART VERSION   APP VERSION     DESCRIPTION
-suse/cf                         &cf_chart;          &chart_appversion;           A Helm chart for &suse; &cf;
+suse/cf                         &kubecf_chart;          &chart_appversion;           A Helm chart for &suse; &cf;
 suse/cf-usb-sidecar-mysql       1.0.1                           A Helm chart for &suse; Universal Service Broker Sidecar fo...
 suse/cf-usb-sidecar-postgres    1.0.1                           A Helm chart for &suse; Universal Service Broker Sidecar fo...
 suse/console                    &stratos_chart;           &chart_appversion;           A Helm chart for deploying Stratos UI Console
@@ -513,7 +513,7 @@ suse/log-agent-rsyslog      	1.0.1        	8.39.0     	Log Agent for forwarding 
 suse/metrics                    &metrics_chart;           &chart_appversion;           A Helm chart for Stratos Metrics
 suse/minibroker                 &minibroker_chart;                           A minibroker for your minikube
 suse/nginx-ingress              0.28.4          0.15.0          An nginx Ingress controller that uses ConfigMap to store ...
-suse/uaa                        &cf_chart;          &chart_appversion;           A Helm chart for &suse; UAA
+suse/uaa                        &kubecf_chart;          &chart_appversion;           A Helm chart for &suse; UAA
 </screen>'>
 
 <!--ENTITY chart-version-fields.............................................-->
@@ -631,17 +631,22 @@ the version of the application as defined in "The <literal>appVersion</literal>
 '<sect1 xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
   <title>Install the &helm; Client</title>
   <para>
-   &helm; is a &kube; package manager. It consists of a client and server
-   component, both of which are required in order to install and manage &cap;.
+   &helm; is a &kube; package manager used to install and manage &productname;.
+   This requires installing the &helm; client, <command>helm</command>, on your
+   remote management workstation. Examples in this guide are based on &helm; 3.
+   For more information regarding &helm;, refer to the documentation at
+   <link xlink:href="https://helm.sh/docs/"/>.
   </para>
   <para>
-   The &helm; client, <literal>helm</literal>, can be installed on your remote
-   administration computer by referring to the documentation at
-   <link xlink:href="https://helm.sh/docs/intro/install/"/>.
-   The examples in this guide are based on &helm; 3. For more information, refer
-   to the documentation at <link xlink:href="https://helm.sh/docs/"/>.
+   If your remote management workstation has the &caasp; package repository,
+   install <command>helm</command> by running
   </para>
- </sect1>'>
+<screen>&prompt.user;sudo zypper install helm</screen>
+  <para>
+   Otherwise, <command>helm</command> can be installed  by referring to the
+   documentation at <link xlink:href="https://helm.sh/docs/intro/install/"/>.
+  </para>
+</sect1>'>
 
 <!--ENTITY scf-deploy-complete..............................................-->
 
@@ -1269,7 +1274,7 @@ agent.log</screen>
 
 <!ENTITY stratos-tech-preview-note
 '<note xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
- <title>Technology Preview Features</title>                           
+ <title>Technology Preview Features</title>
  <para>
   Some Stratos releases may include features as part of a technology preview.
   Technology preview features are for evaluation purposes only and
@@ -1283,5 +1288,134 @@ agent.log</screen>
   . For example, when running <command>helm install</command> add
   <command>--set console.techPreview=true</command>.
  </para>
-</note>'> 
+</note>'>
+
+<!--ENTITY storage-class.....................................................-->
+
+<!ENTITY storage-class
+'<title xmlns="http://docbook.org/ns/docbook">
+  Storage Class
+ </title>
+ <para xmlns="http://docbook.org/ns/docbook">
+  TODO-CAP2 DESCRIPTION OF STORAGE CLASS
+ </para>'>
+
+<!--ENTITY certificates......................................................-->
+
+<!ENTITY certificates
+'<title xmlns="http://docbook.org/ns/docbook">
+  Certificates
+ </title>
+ <para xmlns="http://docbook.org/ns/docbook">
+  TODO-CAP2 DESCRIPTION OF CERTIFICATES
+ </para>'>
+
+<!--ENTITY ingress-controller................................................-->
+
+<!ENTITY ingress-controller
+'<title xmlns="http://docbook.org/ns/docbook">
+  Using an Ingress Controller
+ </title>
+ <para xmlns="http://docbook.org/ns/docbook">
+  TODO-CAP2 DESCRIPTION OF INGRESS CONTROLLER
+ </para>'>
+
+<!--ENTITY high-availability.................................................-->
+
+<!ENTITY high-availability
+'<title xmlns="http://docbook.org/ns/docbook">
+  High Availability
+ </title>
+ <para xmlns="http://docbook.org/ns/docbook">
+  TODO-CAP2 DESCRIPTION OF HIGH AVAILABILITY
+ </para>'>
+
+<!--ENTITY external-database................................................-->
+
+<!ENTITY external-database
+'<title xmlns="http://docbook.org/ns/docbook">
+  External Database
+ </title>
+ <para xmlns="http://docbook.org/ns/docbook">
+  TODO-CAP2 DESCRIPTION OF EXTERNAL DATABASE
+ </para>'>
+
+<!--ENTITY ldap..............................................................-->
+
+<!ENTITY ldap
+'<title xmlns="http://docbook.org/ns/docbook">
+  LDAP Integration
+ </title>
+ <para xmlns="http://docbook.org/ns/docbook">
+  TODO-CAP2 DESCRIPTION OF LDAP
+ </para>'>
+
+<!--ENTITY deploy-operator...................................................-->
+
+<!ENTITY deploy-operator
+'<title xmlns="http://docbook.org/ns/docbook">
+  Deploy the Operator
+ </title>
+ <para xmlns="http://docbook.org/ns/docbook">
+  TODO-CAP2 DESCRIPTION OF OPERATOR
+ </para>
+ <procedure xmlns="http://docbook.org/ns/docbook">
+  <step>
+   <para>
+    First, create the namespace for the operator.
+   </para>
+<screen>&prompt.user;kubectl create namespace <replaceable>cf-operator</replaceable></screen>
+  </step>
+  <step>
+   <para>
+    Install the operator.
+   </para>
+   <para>
+    The value of <literal>global.operator.watchNamespace</literal> indicates the
+    namespace the operator will monitor for a &kubecf; deployment. This
+    namespace should be separate from the namespace used by the operator. In
+    this example, this means &kubecf; will be deployed into a namespace called
+    <literal>kubecf</literal>.
+   </para>
+<screen>&prompt.user;helm install <replaceable>cf-operator</replaceable> TODO-CHART \
+--namespace <replaceable>cf-operator</replaceable> \
+--set "global.operator.watchNamespace=<replaceable>kubecf</replaceable>"
+</screen>
+  </step>
+  <step>
+   <para>
+    Wait until &operator; is successfully deployed before proceeding. Monitor
+    the status of your &operator; deployment using the
+    <command>watch</command> command.
+   </para>
+<screen>&prompt.user;watch --color &apos;kubectl get pods -n cf-operator&apos;</screen>
+   <para>
+    TODO-CAP2 DESCRIPTION OF COMPLETE DEPLOYMENT OF OPERATOR
+    When uaa is successfully deployed, the following is observed:
+   </para>
+  </step>
+ </procedure>'>
+
+<!--ENTITY deploy-kubecf.....................................................-->
+
+<!ENTITY deploy-kubecf
+'<title xmlns="http://docbook.org/ns/docbook">
+  Deploy &kubecf;
+ </title>
+ <para xmlns="http://docbook.org/ns/docbook">
+  TODO-CAP2 DESCRIPTION
+ </para>
+ <procedure xmlns="http://docbook.org/ns/docbook">
+  <step>
+   <para>
+    Use &helm; to deploy &kubecf;.
+   </para>
+<screen>&prompt.user;helm install <replaceable>kubecf</replaceable> TODO-CHART \
+--namespace <replaceable>kubecf</replaceable> \
+--values <replaceable>kubecf-values.yaml</replaceable>
+</screen>
+  </step>
+  <step><para>2222</para></step>
+ </procedure>'>
+
 


### PR DESCRIPTION
- Renames (and shortens) existing entities used to track chart version
- Add `&certificates`, `&ingress-controller`, `&high-availability`, `&external-database`, `&ldap`, `&storage-class` entities. These currently contain TODO placeholders and will need to be populated with the content from the respective chapter or existing section.
- And/replace sections of AKS, CaaSP, EKS, GKE chapters to use above entities 