### PR TITLE
Add note about KubeCF/cf-operator version combinations.

### DIFF
--- a/xml/cap_depl_admin_notes.xml
+++ b/xml/cap_depl_admin_notes.xml
@@ -69,7 +69,7 @@
 
 &dns-tables;
 </sect1>
- <sect1>
+ <sect1 xml:id="cha-cap-depl-notes-releases">
   <title>Releases and Associated Versions</title>
 
   &kubecf-operator-versions;

--- a/xml/cap_depl_admin_notes.xml
+++ b/xml/cap_depl_admin_notes.xml
@@ -72,6 +72,8 @@
  <sect1>
   <title>Releases and Associated Versions</title>
 
+  &kubecf-operator-versions;
+
   <para>
    The supported upgrade method is to install all upgrades, in order. Skipping
    releases is not supported. This table matches the &helm; chart versions to

--- a/xml/cap_depl_aks.xml
+++ b/xml/cap_depl_aks.xml
@@ -421,6 +421,8 @@ suse       https://kubernetes-charts.suse.com/
    AKS load balancer and how to configure your DNS records.
   </para>
 
+    &kubecf-operator-versions;
+
   <!-- TODO-CAP2 -->
   <sect2 xml:id="sec-cap-aks-deploy-operator">
    <title>Deploy <literal>operator</literal></title>

--- a/xml/cap_depl_caasp.xml
+++ b/xml/cap_depl_caasp.xml
@@ -360,6 +360,7 @@ suse       https://kubernetes-charts.suse.com/
 
   <sect2 xml:id="sec-cap-caasp-deploy-scf">
    <title>Deploy <literal>scf</literal></title>
+    &kubecf-operator-versions;
    <para>
     Use &helm; to deploy <literal>scf</literal>:
    </para>

--- a/xml/cap_depl_eks.xml
+++ b/xml/cap_depl_eks.xml
@@ -360,6 +360,8 @@ suse            https://kubernetes-charts.suse.com/</screen>
    configure your DNS records.
   </para>
 
+    &kubecf-operator-versions;
+
   <sect2 xml:id="sec-cap-eks-deploy-operator">
    <title>Deploy <literal>operator</literal></title>
   </sect2>

--- a/xml/cap_depl_gke.xml
+++ b/xml/cap_depl_gke.xml
@@ -303,6 +303,8 @@ suse       https://kubernetes-charts.suse.com/
    configure your DNS records.
   </para>
 
+    &kubecf-operator-versions;
+
   <sect2 xml:id="sec-cap-gke-deploy-operator">
    &deploy-operator;
   </sect2>

--- a/xml/repeated-content-decl.ent
+++ b/xml/repeated-content-decl.ent
@@ -2156,6 +2156,6 @@ User:           username@ldap.example.com
   <para xmlns="http://docbook.org/ns/docbook">
    &kubecf; and &operator; interoperate closely. Before you deploy a
    specific version combination, make sure they were confirmed to work. For more
-   information see <xref linkend="sec-cap-changes"/>.
+   information see <xref linkend="cha-cap-depl-notes-releases"/>.
   </para>
  </warning>'>

--- a/xml/repeated-content-decl.ent
+++ b/xml/repeated-content-decl.ent
@@ -2147,3 +2147,15 @@ User:           username@ldap.example.com
 </screen>
    </listitem>
   </itemizedlist>'>
+
+<!--ENTITY kubecf-operator-versions..........................................-->
+
+<!ENTITY kubecf-operator-versions
+'<warning xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <title>&kubecf; and &operator; versions</title>
+  <para xmlns="http://docbook.org/ns/docbook">
+   &kubecf; and &operator; interoperate closely. Before you deploy a
+   specific version combination, make sure they were confirmed to work. For more
+   information see <xref linkend="sec-cap-changes"/>.
+  </para>
+ </warning>'>


### PR DESCRIPTION
Closes #794. 

I've added the note to:
* all cloud-specific deployment sections just before the installation of KubeCF
* 3.8 Releases and Associated Versions

Locations to consider:
* 11.2 Upgrading SUSE Cloud Application Platform