### PR TITLE
Replace scf with kubecf.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+
+services:
+  daps:
+    image: lkucharczyk/daps
+    container_name: daps
+    volumes:
+      - ./:/files

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,0 @@
-version: '3'
-
-services:
-  daps:
-    image: lkucharczyk/daps
-    container_name: daps
-    volumes:
-      - ./:/files

--- a/xml/app_kubecf_values_yaml.xml
+++ b/xml/app_kubecf_values_yaml.xml
@@ -10,7 +10,7 @@
  xmlns:xi="http://www.w3.org/2001/XInclude"
  xmlns:xlink="http://www.w3.org/1999/xlink"
  version="5.0">
- <title>Complete suse/scf values.yaml File</title>
+ <title>Complete suse/kubecf values.yaml File</title>
 
  <para>
   This is the complete output of <command>helm inspect suse/cf</command> for

--- a/xml/book_cap_guides.xml
+++ b/xml/book_cap_guides.xml
@@ -20,7 +20,7 @@
   <abstract>
    <para>
     Introducing &productname;, a software platform for cloud-native application
-    deployment based on &scf; and &kube;.
+    deployment based on &kubecf; and &kube;.
    </para>
   </abstract>
   <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">

--- a/xml/cap_admin_app_autoscaler.xml
+++ b/xml/cap_admin_app_autoscaler.xml
@@ -17,7 +17,7 @@
  </info>
  <para>
   The App-AutoScaler service is used for automatically managing an
-  application's instance count when deployed on &scf;. The scaling behavior is
+  application's instance count when deployed on &kubecf;. The scaling behavior is
   determined by a set of criteria defined in a policy (See
   <xref linkend="sec-cap-app-autoscaler-policies"/>).
  </para>
@@ -31,7 +31,7 @@
   <itemizedlist>
    <listitem>
     <para>
-     A running deployment of <literal>scf</literal>
+     A running deployment of <literal>kubecf</literal>
     </para>
    </listitem>
 

--- a/xml/cap_admin_app_domains.xml
+++ b/xml/cap_admin_app_domains.xml
@@ -19,8 +19,8 @@
   </dm:docmanager>
  </info>
  <para>
-  In a standard &scf; deployment, applications will use the same domain as the
-  one configured in your &values-filename; for SCF.
+  In a standard &kubecf; deployment, applications will use the same domain as the
+  one configured in your &values-filename; for &kubecf;.
   For example, if <literal>DOMAIN</literal> is set as
   <replaceable>example.com</replaceable> in your
   &values-filename; and you deploy an application
@@ -52,7 +52,7 @@
 
   <para>
    If this is an initial deployment, use <command>helm install</command> to
-   deploy <literal>scf</literal>:
+   deploy <literal>kubecf</literal>:
   </para>
 <screen>&prompt.user;kubectl create namespace <replaceable>kubecf</replaceable>
 
@@ -70,15 +70,15 @@
 --version &kubecf_chart;
 </screen>
 
-  &scf-deploy-complete;
+  &kubecf-deploy-complete;
 
   <para>
-   When the <literal>scf</literal> is complete, do the following to confirm
+   When the <literal>kubecf</literal> is complete, do the following to confirm
    custom application domains have been configured correctly.
   </para>
 
   <para>
-   Run <command>cf curl /v2/info</command> and verify the SCF domain is not
+   Run <command>cf curl /v2/info</command> and verify the &kubecf; domain is not
    <replaceable>appdomain.com</replaceable>:
   </para>
 

--- a/xml/cap_admin_backup-restore.xml
+++ b/xml/cap_admin_backup-restore.xml
@@ -26,11 +26,11 @@
 
   <para>
    <literal>cf-plugin-backup</literal> is not a general-purpose backup and
-   restore plugin. It is designed to save the state of a &scf; instance before
+   restore plugin. It is designed to save the state of a &kubecf; instance before
    making changes to it. If the changes cause problems, use
    <literal>cf-plugin-backup</literal> to restore the instance from scratch. Do
-   not use it to restore to a non-pristine &scf; instance. Some of the
-   limitations for applying the backup to a non-pristine &scf; instance are:
+   not use it to restore to a non-pristine &kubecf; instance. Some of the
+   limitations for applying the backup to a non-pristine &kubecf; instance are:
   </para>
 
   <itemizedlist>
@@ -52,9 +52,9 @@
    </listitem>
    <listitem>
     <para>
-     The set of available stacks is part of the &scf; instance setup, and is
+     The set of available stacks is part of the &kubecf; instance setup, and is
      not part of the CC configuration. Trying to restore applications using
-     stacks not available on the target &scf; instance will fail. Setting up
+     stacks not available on the target &kubecf; instance will fail. Setting up
      the necessary stacks must be performed separately before the backup plugin
      is invoked.
     </para>
@@ -62,7 +62,7 @@
    <listitem>
     <para>
      Buildpacks are not saved. Applications using custom buildpacks not
-     available on the target &scf; instance will not be restored.
+     available on the target &kubecf; instance will not be restored.
      Custom buildpacks must be managed separately, and relevant buildpacks must
      be in place before the affected applications are restored.
     </para>
@@ -332,7 +332,7 @@
    <para>
     <command>cf backup-restore</command> reads the
     <filename>cf-backup.json</filename> snapshot file found in the current
-    working directory, and then talks to the targeted &scf; instance to upload
+    working directory, and then talks to the targeted &kubecf; instance to upload
     the following information, in the specified order:
    </para>
    <itemizedlist>
@@ -512,7 +512,7 @@
    An existing &productname; deployment's data can be migrated to a new
    &productname; deployment through a backup and restore of its raw data. The
    process involves performing a backup and restore of the
-   <literal>scf</literal> components respectively. This procedure is agnostic of
+   <literal>kubecf</literal> components respectively. This procedure is agnostic of
    the underlying &kube; infrastructure and can be included as part of your
    disaster recovery solution.
   </para>
@@ -527,13 +527,13 @@
    <itemizedlist>
     <listitem>
      <para>
-      Access to a running deployment of <literal>scf</literal> to create backups
+      Access to a running deployment of <literal>kubecf</literal> to create backups
       with
      </para>
     </listitem>
     <listitem>
      <para>
-      Access to new deployments of <literal>scf</literal> (deployed with a
+      Access to new deployments of <literal>kubecf</literal> (deployed with a
       &values-filename; configured according to
       <xref linkend="prepare-config-for-new-cluster"/> of
       <xref linkend="sec-cap-raw-data-restore-procedure"/>) to perform the
@@ -608,13 +608,13 @@
     <para>
      This process is intended for backing up and restoring to a target
      deployment with the same version as the source deployment. For example,
-     data from a backup of <literal>scf</literal> version 2.18.0 should be
-     restored to a version version 2.18.0 <literal>scf</literal> deployment.
+     data from a backup of <literal>kubecf</literal> version 2.18.0 should be
+     restored to a version version 2.18.0 <literal>kubecf</literal> deployment.
     </para>
    </note>
    <para>
     Perform the following steps to create a backup of your source
-    <literal>scf</literal> deployment.
+    <literal>kubecf</literal> deployment.
    </para>
    <procedure>
     <step>
@@ -635,7 +635,7 @@
      <para>
       Copy the archive to a location outside of the pod:
      </para>
-<screen>&prompt.user;kubectl cp scf/blobstore-0:blobstore-src.tgz <replaceable>/tmp/blobstore-src.tgz</replaceable></screen>
+<screen>&prompt.user;kubectl cp kubecf/blobstore-0:blobstore-src.tgz <replaceable>/tmp/blobstore-src.tgz</replaceable></screen>
     </step>
     <step>
      <para>
@@ -696,12 +696,12 @@
    </important>
    <para>
     Perform the following steps to restore your backed up data to the target
-    <literal>scf</literal> deployment.
+    <literal>kubecf</literal> deployment.
    </para>
    <procedure>
     <step xml:id="prepare-config-for-new-cluster">
      <para>
-      The target <literal>scf</literal> cluster needs to be deployed with the
+      The target <literal>kubecf</literal> cluster needs to be deployed with the
       correct database encryption key(s) set in your
       &values-filename; before data can be restored.
       How the encryption key(s) will be prepared in your
@@ -748,7 +748,7 @@ secrets:
     </step>
     <step>
      <para>
-      Deploy a non-high-availability configuration of <literal>scf</literal>
+      Deploy a non-high-availability configuration of <literal>kubecf</literal>
       and wait until all pods are ready before proceeding.
      </para>
     </step>
@@ -777,7 +777,7 @@ done
       Copy the <filename>blobstore-src.tgz</filename> archive to the
       <literal>blobstore</literal> pod:
      </para>
-<screen>&prompt.user;kubectl cp <replaceable>/tmp/blobstore-src.tgz</replaceable> scf/blobstore-0:/.</screen>
+<screen>&prompt.user;kubectl cp <replaceable>/tmp/blobstore-src.tgz</replaceable> kubecf/blobstore-0:/.</screen>
     </step>
     <step>
      <para>

--- a/xml/cap_admin_create_admin.xml
+++ b/xml/cap_admin_create_admin.xml
@@ -50,7 +50,7 @@
     <para>
      Create a new user:
     </para>
-    <screen>&prompt.user;uaac user add <replaceable>new-admin</replaceable> --password <replaceable>password</replaceable> --emails <replaceable>new-admin@example.com</replaceable> --zone <replaceable>scf</replaceable></screen>
+    <screen>&prompt.user;uaac user add <replaceable>new-admin</replaceable> --password <replaceable>password</replaceable> --emails <replaceable>new-admin@example.com</replaceable> --zone <replaceable>kubecf</replaceable></screen>
    </step>
    <step>
     <para>
@@ -58,21 +58,21 @@
      to the cluster (see
      <link xlink:href="https://docs.cloudfoundry.org/concepts/architecture/uaa.html#uaa-scopes"/> for information on privileges provided by each group):
     </para>
-<screen>&prompt.user;uaac member add scim.write <replaceable>new-admin</replaceable> --zone <replaceable>scf</replaceable>
+<screen>&prompt.user;uaac member add scim.write <replaceable>new-admin</replaceable> --zone <replaceable>kubecf</replaceable>
 
-&prompt.user;uaac member add scim.read <replaceable>new-admin</replaceable> --zone <replaceable>scf</replaceable>
+&prompt.user;uaac member add scim.read <replaceable>new-admin</replaceable> --zone <replaceable>kubecf</replaceable>
 
-&prompt.user;uaac member add cloud_controller.admin <replaceable>new-admin</replaceable> --zone <replaceable>scf</replaceable>
+&prompt.user;uaac member add cloud_controller.admin <replaceable>new-admin</replaceable> --zone <replaceable>kubecf</replaceable>
 
-&prompt.user;uaac member add clients.read <replaceable>new-admin</replaceable> --zone <replaceable>scf</replaceable>
+&prompt.user;uaac member add clients.read <replaceable>new-admin</replaceable> --zone <replaceable>kubecf</replaceable>
 
-&prompt.user;uaac member add clients.write <replaceable>new-admin</replaceable> --zone <replaceable>scf</replaceable>
+&prompt.user;uaac member add clients.write <replaceable>new-admin</replaceable> --zone <replaceable>kubecf</replaceable>
 
-&prompt.user;uaac member add doppler.firehose <replaceable>new-admin</replaceable> --zone <replaceable>scf</replaceable>
+&prompt.user;uaac member add doppler.firehose <replaceable>new-admin</replaceable> --zone <replaceable>kubecf</replaceable>
 
-&prompt.user;uaac member add routing.router_groups.read <replaceable>new-admin</replaceable> --zone <replaceable>scf</replaceable>
+&prompt.user;uaac member add routing.router_groups.read <replaceable>new-admin</replaceable> --zone <replaceable>kubecf</replaceable>
 
-&prompt.user;uaac member add routing.router_groups.write <replaceable>new-admin</replaceable> --zone <replaceable>scf</replaceable>
+&prompt.user;uaac member add routing.router_groups.write <replaceable>new-admin</replaceable> --zone <replaceable>kubecf</replaceable>
 </screen>
    </step>
    <step>

--- a/xml/cap_admin_nproc_limits.xml
+++ b/xml/cap_admin_nproc_limits.xml
@@ -26,12 +26,12 @@
 
  <para>
   Nproc is the maximum number of processes allowed per user. In the case of
-  <literal>scf</literal>, the nproc value applies to the
-  <literal>vcap</literal> user. In <literal>scf</literal>, there are parameters,
+  <literal>kubecf</literal>, the nproc value applies to the
+  <literal>vcap</literal> user. In <literal>kubecf</literal>, there are parameters,
   <command>kube.limits.nproc.soft</command> and
   <command>kube.limits.nproc.hard</command>, to configure a soft nproc limit
   and a hard nproc limit for processes spawned by the <literal>vcap</literal>
-  user in <literal>scf</literal> pods. By default, the soft limit is 1024 while
+  user in <literal>kubecf</literal> pods. By default, the soft limit is 1024 while
   the hard limit is 2048. The soft and hard limits can be changed
   to suit your workloads. Note that the limits are applied to all pods.
  </para>
@@ -85,7 +85,7 @@
    <procedure>
     <step>
      <para>
-      Deploy <literal>scf</literal>:
+      Deploy <literal>kubecf</literal>:
      </para>
 <screen>&prompt.user;kubectl create namespace <replaceable>kubecf</replaceable>
 

--- a/xml/cap_admin_secret_rotation.xml
+++ b/xml/cap_admin_secret_rotation.xml
@@ -28,7 +28,7 @@
   <command>helm upgrade</command>.
  </para>
  <para>
-  This example demonstrates rotating the secrets of the <literal>scf</literal>
+  This example demonstrates rotating the secrets of the <literal>kubecf</literal>
   deployment.
  </para>
  <para>

--- a/xml/cap_depl_aks.xml
+++ b/xml/cap_depl_aks.xml
@@ -524,7 +524,7 @@ suse       https://kubernetes-charts.suse.com/
   </para>
 <screen>&prompt.user;watch --color 'kubectl get pods --namespace osba'</screen>
   <para>
-   When all pods are running, create the service broker in &scf; using the &cfcli;:
+   When all pods are running, create the service broker in &kubecf; using the &cfcli;:
   </para>
 <screen>
 &prompt.user;cf login
@@ -556,9 +556,9 @@ awk '($2 ~ /basic/) { system("cf enable-service-access " $1 " -p " $2)}'
 <screen>
 &prompt.user;cf create-org <replaceable>testorg</replaceable>
 
-&prompt.user;cf create-space <replaceable>scftest</replaceable> -o <replaceable>testorg</replaceable>
+&prompt.user;cf create-space <replaceable>kubecftest</replaceable> -o <replaceable>testorg</replaceable>
 
-&prompt.user;cf target -o "<replaceable>testorg</replaceable>" -s "<replaceable>scftest</replaceable>"
+&prompt.user;cf target -o "<replaceable>testorg</replaceable>" -s "<replaceable>kubecftest</replaceable>"
 
 &prompt.user;cf create-service azure-mysql-5-7 basic <replaceable>question2answer-db</replaceable> \
 -c "{ \"location\": \"${REGION}\", \"resourceGroup\": \"${SBRG_NAME}\", \"firewallRules\": [{\"name\": \
@@ -579,7 +579,7 @@ awk '($2 ~ /basic/) { system("cf enable-service-access " $1 " -p " $2)}'
 &prompt.user;az mysql server list --resource-group $SBRG_NAME
 
 &prompt.user;az mysql server update --resource-group $SBRG_NAME \
---name <replaceable>scftest</replaceable> --ssl-enforcement Disabled
+--name <replaceable>kubecftest</replaceable> --ssl-enforcement Disabled
 </screen>
 
   <para>

--- a/xml/cap_depl_caasp.xml
+++ b/xml/cap_depl_caasp.xml
@@ -197,10 +197,10 @@
     </para>
     <para>
      If you are using &ses; you must copy the Ceph admin secret to the
-     <literal>scf</literal> namespaces used by &productname;:
+     <literal>kubecf</literal> namespaces used by &productname;:
     </para>
 <screen>&prompt.user;kubectl get secret ceph-secret-admin --output json --namespace default | \
-sed's/"namespace": "default"/"namespace": "scf"/' | kubectl create --filename -
+sed's/"namespace": "default"/"namespace": "kubecf"/' | kubectl create --filename -
 </screen>
    </listitem>
    <listitem>

--- a/xml/cap_depl_eirini.xml
+++ b/xml/cap_depl_eirini.xml
@@ -86,7 +86,7 @@ env:
    </step>
    <step>
     <para>
-     Deploy <literal>scf</literal>.
+     Deploy <literal>kubecf</literal>.
     </para>
     <para>
      Refer to the following for platform-specific instructions:
@@ -96,13 +96,13 @@ env:
    <step>
     <para>
      After initiating the <command>helm install</command> command to deploy
-     <literal>scf</literal>, The secret generator will create a certificate
+     <literal>kubecf</literal>, The secret generator will create a certificate
      signing request that must be approved by an administrator before deployment
-     will continue. To do so, run the command below where <literal>scf</literal>
-     should be replaced with your namespace of your <literal>scf</literal>
+     will continue. To do so, run the command below where <literal>kubecf</literal>
+     should be replaced with your namespace of your <literal>kubecf</literal>
      deployment.
     </para>
-<screen>&prompt.user;kubectl certificate approve <replaceable>scf</replaceable>-bits-service-ssl-cert</screen>
+<screen>&prompt.user;kubectl certificate approve <replaceable>kubecf</replaceable>-bits-service-ssl-cert</screen>
     <para>
      Note that manual approval of CSRs is recommended.
     </para>

--- a/xml/cap_depl_eks.xml
+++ b/xml/cap_depl_eks.xml
@@ -400,7 +400,7 @@ suse            https://kubernetes-charts.suse.com/</screen>
     </step>
     <step>
      <para>
-      Create a service broker in <literal>scf</literal>. Note the name of the
+      Create a service broker in <literal>kubecf</literal>. Note the name of the
       service broker should be the same as the one specified for the
       the <command>helm install</command> step (for example
       <literal>aws-servicebroker</literal>. Note that the username and password
@@ -471,7 +471,7 @@ suse            https://kubernetes-charts.suse.com/</screen>
     </step>
     <step>
      <para>
-      Delete the service broker in <literal>scf</literal>:
+      Delete the service broker in <literal>kubecf</literal>:
      </para>
 <screen>&prompt.user;cf delete-service-broker aws-servicebroker</screen>
     </step>

--- a/xml/cap_depl_gke.xml
+++ b/xml/cap_depl_gke.xml
@@ -338,7 +338,7 @@ suse       https://kubernetes-charts.suse.com/
   </para>
   <para>
    This section describes the how to deploy and use the GCP Service Broker, as a
-   &scf; application, on &productname;.
+   &kubecf; application, on &productname;.
   </para>
 
   <sect2 xml:id="sec-cap-gke-service-broker-apis">
@@ -822,7 +822,7 @@ applications:
     </step>
     <step>
      <para>
-      Create the service broker in &scf; using the &cfcli;.
+      Create the service broker in &kubecf; using the &cfcli;.
      </para>
 <screen>&prompt.user;cf create-service-broker <replaceable>gcp-service-broker</replaceable> <replaceable>cfgcpbrokeruser</replaceable> <replaceable>cfgcpbrokerpassword</replaceable> <replaceable>https://gcp-service-broker.example.com</replaceable></screen>
      <para>

--- a/xml/cap_depl_stratos.xml
+++ b/xml/cap_depl_stratos.xml
@@ -20,7 +20,7 @@
    The Stratos user interface (UI) is a modern web-based management application
    for &cf;. It provides a graphical management console for both
    developers and system administrators. Install Stratos with &helm; after all
-   of the <literal>scf</literal> pods are running.
+   of the <literal>kubecf</literal> pods are running.
   </para>
 
  <sect1 xml:id="sec-cap-stratos-prod">
@@ -32,7 +32,7 @@
       &productname; domain as described in
       <xref linkend="sec-cap-caasp-config"/>. These instructions assume you
       have followed the procedure in <xref linkend="cha-cap-depl-caasp"/>,
-      have deployed <literal>scf</literal> successfully, and have created a
+      have deployed <literal>kubecf</literal> successfully, and have created a
       default storage class.
  </para>
 
@@ -56,7 +56,7 @@ sed 's/"namespace": "default"/"namespace": "stratos"/' | kubectl create --filena
  <para>
      Use &helm; to install Stratos, using the same
      &values-filename; configuration file you used to
-     deploy <literal>scf</literal>:
+     deploy <literal>kubecf</literal>:
   </para>
 
   &stratos-tech-preview-note;
@@ -213,7 +213,7 @@ stratos  1        1        3h
   <title>Deploy Stratos on &eks;</title>
 
   <para>
-   Before deploying Stratos, ensure <literal>scf</literal> has been successfully
+   Before deploying Stratos, ensure <literal>kubecf</literal> has been successfully
    deployed on &eks; (see <xref linkend="cha-cap-depl-eks"/>).
   </para>
   <para>
@@ -379,7 +379,7 @@ gp2scoped       kubernetes.io/aws-ebs   1d
   <title>Deploy Stratos on &aks;</title>
 
   <para>
-   Before deploying Stratos, ensure <literal>scf</literal> has been successfully
+   Before deploying Stratos, ensure <literal>kubecf</literal> has been successfully
    deployed on &aks; (see <xref linkend="cha-cap-depl-aks"/>).
   </para>
 
@@ -498,7 +498,7 @@ gp2scoped       kubernetes.io/aws-ebs   1d
   <title>Deploy Stratos on &gke;</title>
 
   <para>
-   Before deploying Stratos, ensure <literal>scf</literal> has been successfully
+   Before deploying Stratos, ensure <literal>kubecf</literal> has been successfully
    deployed on &gke; (see <xref linkend="cha-cap-depl-gke"/>).
   </para>
 
@@ -622,7 +622,7 @@ gp2scoped       kubernetes.io/aws-ebs   1d
 
   <para>
    For instructions to upgrade Stratos, follow the process described in
-   <xref linkend="cha-cap-upgrade"/>. Take note that <literal>scf</literal> is
+   <xref linkend="cha-cap-upgrade"/>. Take note that <literal>kubecf</literal> is
    upgraded prior to upgrading Stratos.
   </para>
  </sect1>
@@ -796,7 +796,7 @@ firehoseExporter:
     <literal>stratos-metrics</literal> &helm; chart. As with deploying Stratos,
     you should deploy the metrics &helm; chart using the same
     &values-filename; file that was used for deploying
-    <literal>scf</literal>.
+    <literal>kubecf</literal>.
    </para>
    <para>
     Additionally, create a new YAML file, named

--- a/xml/cap_overview.xml
+++ b/xml/cap_overview.xml
@@ -97,16 +97,16 @@
 
   <para>
    &productname; describes the complete software stack, including the operating
-   system, &kube;, and &scf;.
+   system, &kube;, and &kubecf;.
   </para>
 
   <para>
-   &productname; is comprised of &scf; (<literal>scf</literal>), the Stratos
+   &productname; is comprised of &kubecf; (<literal>kubecf</literal>), the Stratos
    Web user interface, and Stratos Metrics.
   </para>
 
   <para>
-   The &cf; code base provides the basic functionality. &scf; differentiates
+   The &cf; code base provides the basic functionality. &kubecf; differentiates
    itself from other &cf; distributions by running in Linux containers managed
    by &kube;, rather than virtual machines managed with &bosh;, for greater
    fault tolerance and lower memory use.
@@ -210,8 +210,8 @@
 
   <para>
    The principle interface and API for deploying applications to &productname;
-   is &scf;. Most &cf; distributions run on virtual machines managed
-   by &bosh;. &scf; runs in &sle; containers managed by &kube;.
+   is &kubecf;. Most &cf; distributions run on virtual machines managed
+   by &bosh;. &kubecf; runs in &sle; containers managed by &kube;.
    Containerizing the components of the platform itself has these advantages:
   </para>
 
@@ -225,7 +225,7 @@
    </listitem>
    <listitem>
     <para>
-     Reduces physical memory overhead. &scf; components deployed in containers
+     Reduces physical memory overhead. &kubecf; components deployed in containers
      consume substantially less memory, as host-level operations are shared
      between containers by &kube;.
     </para>
@@ -244,7 +244,7 @@
   <title>Minimum Requirements</title>
 
   <para>
-   This guide details the steps for deploying &scf; on
+   This guide details the steps for deploying &kubecf; on
    supported &kube; environments, namely &caasp;, &aks-full;, &gke-full;, and &eks-full;.
   </para>
 
@@ -254,7 +254,7 @@
     Installing and administering &productname; requires knowledge of Linux,
     &docker;, &kube;, and your &kube; platform. You must plan resource allocation
     and network architecture by taking into account the requirements of your
-    &kube; platform in addition to &scf; requirements. &scf; is a discrete
+    &kube; platform in addition to &kubecf; requirements. &kubecf; is a discrete
     component in your cloud stack, but it still requires knowledge of
     administering and troubleshooting the underlying stack.
    </para>
@@ -263,11 +263,11 @@
   <para>
    You may create a minimal deployment on four &kube; nodes for testing.
    However, this is insufficient for a production deployment. A supported
-   deployment includes &scf; installed on &caasp;, &eks;, &gke;, or &aks;.
+   deployment includes &kubecf; installed on &caasp;, &eks;, &gke;, or &aks;.
    You also need a storage back-end such as &ses; or NFS, a DNS/DHCP
    server, and an Internet connection to download additional packages during
    installation and ~10 GB of &docker; images. <xref linkend="fig-cap-min-prod-arch"/> describes a minimal production
-   deployment with &scf; deployed on a &kube; cluster containing three &kube;
+   deployment with &kubecf; deployed on a &kube; cluster containing three &kube;
    masters and three workers, plus an ingress controller, administration
    workstation, DNS/DHCP server, and a &ses; cluster.
   </para>
@@ -289,7 +289,7 @@
   <para>
    Note that after you have deployed your cluster and start building and
    running applications, your applications may depend on buildpacks that are
-   not bundled in the container images that ship with &scf;. These will be
+   not bundled in the container images that ship with &kubecf;. These will be
    downloaded at runtime, when you are pushing applications to the platform.
    Some of these buildpacks may include components with proprietary licenses.
    (See
@@ -391,15 +391,15 @@
   </figure>
 
   <sect2 xml:id="sec-cap-components">
-   <title>&scf; Components</title>
+   <title>&kubecf; Components</title>
    <para>
-    &scf; is comprised of developer and administrator clients, trusted download
+    &kubecf; is comprised of developer and administrator clients, trusted download
     sites, transient and long-running components, APIs, and authentication:
    </para>
    <itemizedlist>
     <listitem>
      <para>
-      Clients for developers and admins to interact with &scf;: the &cfcli;,
+      Clients for developers and admins to interact with &kubecf;: the &cfcli;,
       which provides the <command>cf</command> command, Stratos Web interface,
       IDE plugins.
      </para>
@@ -438,19 +438,19 @@
     </listitem>
     <listitem>
      <para>
-      Long-running &scf; components.
+      Long-running &kubecf; components.
      </para>
     </listitem>
     <listitem>
      <para>
-      &scf; post-deployment components: Transient &scf; components that start
-      after all &scf; components are started, perform their tasks, and then
+      &kubecf; post-deployment components: Transient &kubecf; components that start
+      after all &kubecf; components are started, perform their tasks, and then
       exit.
      </para>
     </listitem>
     <listitem>
      <para>
-      &scf; Linux cell, an elastic runtime component that runs Linux
+      &kubecf; Linux cell, an elastic runtime component that runs Linux
       applications.
      </para>
     </listitem>
@@ -469,13 +469,13 @@
   </sect2>
 
   <sect2 xml:id="sec-cap-containers">
-   <title>&scf; Containers</title>
+   <title>&kubecf; Containers</title>
    <para>
-    <xref linkend="fig-cap-cap-containers"/> provides a look at &scf;'s
+    <xref linkend="fig-cap-cap-containers"/> provides a look at &kubecf;'s
     containers.
    </para>
    <figure xml:id="fig-cap-cap-containers">
-    <title>&scf; Containers, Grouped by Function</title>
+    <title>&kubecf; Containers, Grouped by Function</title>
     <mediaobject>
      <imageobject role="fo">
       <imagedata fileref="cap-containers.svg" format="SVG" width="75%"/>
@@ -483,13 +483,13 @@
      <imageobject role="html">
       <imagedata fileref="cap-containers.svg" format="SVG"/>
      </imageobject>
-     <textobject role="description"><phrase>&scf;'s containers, grouped
+     <textobject role="description"><phrase>&kubecf;'s containers, grouped
             by functionality.</phrase>
      </textobject>
     </mediaobject>
    </figure>
    <variablelist>
-    <title>List of &scf; Containers</title>
+    <title>List of &kubecf; Containers</title>
     <varlistentry>
      <term>adapter</term>
      <listitem>
@@ -503,7 +503,7 @@
      <term>api-group</term>
      <listitem>
       <para>
-       Contains the &scf; Cloud Controller, which implements the CF API. It is
+       Contains the &kubecf; Cloud Controller, which implements the CF API. It is
        exposed via the router.
       </para>
      </listitem>
@@ -569,7 +569,7 @@
      <term>diego-cell (privileged)</term>
      <listitem>
       <para>
-       The elastic layer of &scf;, where applications live.
+       The elastic layer of &kubecf;, where applications live.
       </para>
      </listitem>
     </varlistentry>
@@ -703,9 +703,9 @@
   </sect2>
 
   <sect2 xml:id="sec-cap-service-diagram">
-   <title>&scf; Service Diagram</title>
+   <title>&kubecf; Service Diagram</title>
    <para>
-    This simple service diagram illustrates how &scf; components communicate
+    This simple service diagram illustrates how &kubecf; components communicate
     with each other (<xref linkend="fig-cap-simple-services"/>). See
     <xref linkend="fig-cap-detailed-services"/> for a more detailed view.
    </para>
@@ -872,7 +872,7 @@
        </entry>
        <entry>
 	<para>
-	 &scf; components ask <literal>uaa</literal> for tokens so they can talk
+	 &kubecf; components ask <literal>uaa</literal> for tokens so they can talk
 	 to each other
 	</para>
        </entry>
@@ -888,10 +888,10 @@
        </entry>
        <entry>
         <para>
-         <emphasis role="bold">Requestor</emphasis>: &scf; clients
+         <emphasis role="bold">Requestor</emphasis>: &kubecf; clients
 	</para>
         <para>
-         <emphasis role="bold">Request</emphasis>: &scf; API Requests
+         <emphasis role="bold">Request</emphasis>: &kubecf; API Requests
 	</para>
        </entry>
        <entry>
@@ -900,7 +900,7 @@
 	 token
         </para>
         <para>                                                                  
-	 <emphasis role="bold">Request Authorization</emphasis>: &scf;
+	 <emphasis role="bold">Request Authorization</emphasis>: &kubecf;
 	 application management             
         </para>
        </entry>
@@ -919,7 +919,7 @@
        </entry>
        <entry>
         <para>
-	 &cap; Clients interact with the &scf; API (for example users deploying
+	 &cap; Clients interact with the &kubecf; API (for example users deploying
 	 apps)
         </para>
        </entry>
@@ -935,7 +935,7 @@
        </entry>
        <entry>
         <para>
-         <emphasis role="bold">Requestor</emphasis>: &scf; clients
+         <emphasis role="bold">Requestor</emphasis>: &kubecf; clients
 	</para>
 	<para>
          <emphasis role="bold">Request</emphasis>: Log streaming
@@ -947,7 +947,7 @@
 	 token
 	</para>
 	<para>
-	 <emphasis role="bold">Request Authorization</emphasis>: &scf;
+	 <emphasis role="bold">Request Authorization</emphasis>: &kubecf;
 	 application management
 	</para>
        </entry>
@@ -956,7 +956,7 @@
          <emphasis role="bold">Listener</emphasis>: &cap; components
 	</para>
 	<para>
-         <emphasis role="bold">Response</emphasis>: A stream of &scf; logs
+         <emphasis role="bold">Response</emphasis>: A stream of &kubecf; logs
 	</para>
 	<para>
 	 <emphasis role="bold">Response Credentials</emphasis>: TLS certificate
@@ -965,7 +965,7 @@
        </entry>
        <entry>
 	<para>
-	 &scf; clients ask for logs (for example user looking at application
+	 &kubecf; clients ask for logs (for example user looking at application
 	 logs or administrator viewing system logs)
 	</para>
        </entry> 
@@ -981,7 +981,7 @@
        </entry>
        <entry>
         <para>
-         <emphasis role="bold">Requestor</emphasis>: &scf; clients, SSH clients
+         <emphasis role="bold">Requestor</emphasis>: &kubecf; clients, SSH clients
 	</para>
 	<para>
          <emphasis role="bold">Request</emphasis>: SSH Access to Application
@@ -993,7 +993,7 @@
 	 token
 	</para>
 	<para>
-	 <emphasis role="bold">Request Authorization</emphasis>: &scf;
+	 <emphasis role="bold">Request Authorization</emphasis>: &kubecf;
 	 application management
 	</para>
        </entry>
@@ -1012,7 +1012,7 @@
        </entry> 
        <entry>
 	<para>
-	 &scf; Clients open an SSH connection to an application's container (for
+	 &kubecf; Clients open an SSH connection to an application's container (for
 	 example users debugging their applications)
 	</para>
        </entry>
@@ -1071,7 +1071,7 @@
    <title>Detailed Services Diagram</title>
    <para>
     <xref linkend="fig-cap-detailed-services"/> presents a more detailed view
-    of &scf; services and how they interact with each other. Services labeled
+    of &kubecf; services and how they interact with each other. Services labeled
     in red are unencrypted, while services labeled in green run over HTTPS.
    </para>
    <figure xml:id="fig-cap-detailed-services">

--- a/xml/cap_troubleshooting.xml
+++ b/xml/cap_troubleshooting.xml
@@ -18,7 +18,7 @@
  <para>
   Cloud stacks are complex, and debugging deployment issues often requires
   digging through multiple layers to find the information you need. Remember
-  that the &scf; releases must be deployed in the correct order, and that each
+  that the &kubecf; releases must be deployed in the correct order, and that each
   release must deploy successfully, with no failed pods, before deploying the
   next release.
  </para>
@@ -125,7 +125,8 @@ routing-api-0            0/1   Running   0         16h</screen>
   </para>
 
   <para>
-   The namespace is also deleted as part of the process because the SCF 
+   The namespace is also deleted as part of the process because the
+   <literal>kubecf</literal>
    namespace contain generated secrets which Helm is not aware of and will not
    remove when a release is deleted. When deleting a release, busy systems may
    encounter timeouts. By first deleting the StatefulSets, it ensures that this
@@ -141,12 +142,12 @@ routing-api-0            0/1   Running   0         16h</screen>
 <screen>&prompt.user;helm list
 NAME            REVISION  UPDATED                  STATUS    CHART           NAMESPACE
 <replaceable>susecf-console</replaceable>  1         Tue Aug 14 11:53:28 2018 DEPLOYED  &stratos_chart;   stratos
-<replaceable>kubecf</replaceable>      1         Tue Aug 14 10:58:16 2018 DEPLOYED  &kubecf_chart;       scf
+<replaceable>kubecf</replaceable>      1         Tue Aug 14 10:58:16 2018 DEPLOYED  &kubecf_chart;       kubecf
 </screen>
 
   <para>
    This example deletes the <literal>kubecf</literal> release and
-   <literal>scf</literal> namespace:
+   <literal>kubecf</literal> namespace:
   </para>
 
 <screen>&prompt.user;kubectl delete statefulsets --all --namespace kubecf
@@ -157,8 +158,8 @@ statefulset "api-group" deleted
 &prompt.user;helm delete kubecf
 release "kubecf" deleted
 
-&prompt.user;kubectl delete namespace scf
-namespace "scf" deleted</screen>
+&prompt.user;kubectl delete namespace kubecf
+namespace "kubecf" deleted</screen>
 
  <para>
    Then you can start over. Be sure to create new release and namespace names.

--- a/xml/cap_user_cf_cli.xml
+++ b/xml/cap_user_cf_cli.xml
@@ -42,7 +42,7 @@
   </para>
 
 <screen>       NOTES:
-    Welcome to your new deployment of SCF.
+    Welcome to your new deployment of &kubecf;.
 
     The endpoint for use by the `cf` client is
         https://api.example.com

--- a/xml/repeated-content-decl.ent
+++ b/xml/repeated-content-decl.ent
@@ -434,9 +434,9 @@ the version of the application as defined in "The <literal>appVersion</literal>
   </para>
 </sect1>'>
 
-<!--ENTITY scf-deploy-complete..............................................-->
+<!--ENTITY kubecf-deploy-complete..............................................-->
 
-<!ENTITY scf-deploy-complete
+<!ENTITY kubecf-deploy-complete
 '<para xmlns="http://docbook.org/ns/docbook">
   Wait until you have a successful <literal>scf</literal> deployment before
   going to the next steps, which you can monitor with the
@@ -444,7 +444,7 @@ the version of the application as defined in "The <literal>appVersion</literal>
  </para>
 <screen xmlns="http://docbook.org/ns/docbook">&prompt.user;watch --color &apos;kubectl get pods --namespace kubecf&apos;</screen>
  <para xmlns="http://docbook.org/ns/docbook">
-  When <literal>scf</literal> is successfully deployed, the following is
+  When <literal>kubecf</literal> is successfully deployed, the following is
   observed:
  </para>
  <itemizedlist xmlns="http://docbook.org/ns/docbook">
@@ -944,7 +944,7 @@ done
      </para>
      <para>
       The following example retrieves the logs of the <literal>router</literal>
-      container of <literal>router-0</literal> pod in the <literal>scf</literal>
+      container of <literal>router-0</literal> pod in the <literal>kubecf</literal>
       namespace
      </para>
 <screen>&prompt.user;kubectl logs --namespace kubecf <replaceable>router-0</replaceable> <replaceable>router</replaceable></screen>
@@ -1247,7 +1247,7 @@ nginx-ingress-controller   LoadBalancer   <replaceable>10.63.248.70</replaceable
    <title>Finding Default and Allowable Sizing Values</title>
    <para>
     The <literal>sizing:</literal> section in the &helm;
-    <filename>values.yaml</filename> files for the <literal>scf</literal> chart
+    <filename>values.yaml</filename> files for the <literal>kubecf</literal> chart
     describes which roles can be scaled, and the scaling options for each role.
     You may use <command>helm inspect</command> to read the
     <literal>sizing:</literal> section in the &helm; chart:
@@ -1598,7 +1598,7 @@ perl -ne &apos;/^sizing/..0 and do { print $.,":",$_ if /^ [a-z]/ || /high avail
    <step>
     <para>
      Verify the LDAP identify provider has been created in the
-     <replaceable>scf</replaceable> zone. The output should now contain an entry for
+     <replaceable>kubecf</replaceable> zone. The output should now contain an entry for
      the <literal>ldap</literal> type.
     </para>
 <screen>&prompt.user;uaac curl /identity-providers --insecure --header "X-Identity-Zone-Id: <replaceable>uaa</replaceable>"</screen>


### PR DESCRIPTION
Replaced most of occurences with "kubecf" or "&kubecf;". Remaining occurences:

```
$ grep -rni "scf" xml
xml/cap_depl_aks.xml:594:&prompt.user;git clone https://github.com/scf-samples/question2answer
xml/cap_admin_buildpacks.xml:515:<screen>&prompt.user;git clone <replaceable>https://github.com/scf-samples/12factor</replaceable>
xml/repeated-content-decl.ent:441:  Wait until you have a successful <literal>scf</literal> deployment before
xml/repeated-content-decl.ent:509:   As of &scf; 2.18.0, since our <literal>cf-deployment</literal> version is 9.5
xml/repeated-content-decl.ent:511:   advised in &scf; 2.17.1 or &cap; 1.4.1. The <literal>cflinuxfs2</literal>
xml/cap_admin_service_broker.xml:346: <screen>&prompt.user;git clone https://github.com/scf-samples/cf-redis-example-app
xml/cap_admin_logging.xml:43:  SCF_LOG_HOST: elk.example.com
xml/cap_admin_logging.xml:44:  SCF_LOG_PORT: 5001
xml/cap_admin_logging.xml:45:  SCF_LOG_PROTOCOL: "tcp"</screen>
xml/cap_admin_logging.xml:135:     <filename>/etc/logstash/conf.d/00-scf.conf</filename>. In this example, we
xml/cap_admin_logging.xml:136:     will name it <filename>00-scf.conf</filename>. Add the following into the
xml/cap_admin_logging.xml:138:     need to match the value of the <literal>SCF_LOG_PORT</literal> property in
xml/cap_admin_logging.xml:150:    index => "scf-%{+YYYY.MM.dd}"
xml/entity-decl.ent:35:<!ENTITY scf          "&suse; Cloud Foundry">
xml/entity-decl.ent:305:    does not remove generated secrets from the SCF and UAA namespaces as it is
xml/cap_depl_eirini.xml:84:     <link xlink:href="https://github.com/SUSE/scf/wiki/Persistence-with-Eirini-in-SCF"/>.
```

With more context:
```
Searching 46 files for "scf"

/home/lukas/work/doc-cap/xml/cap_admin_buildpacks.xml:
  513        Deploy a sample Rails app using the new buildpack:
  514       </para>
  515: <screen>&prompt.user;git clone <replaceable>https://github.com/scf-samples/12factor</replaceable>
  516  &prompt.user;cd <replaceable>12factor</replaceable>
  517  &prompt.user;cf push <replaceable>12factor</replaceable> -b <replaceable>ruby_buildpack_cached</replaceable>

/home/lukas/work/doc-cap/xml/cap_admin_logging.xml:
   41     </para>
   42  <screen>env:
   43:   SCF_LOG_HOST: elk.example.com
   44:   SCF_LOG_PORT: 5001
   45:   SCF_LOG_PROTOCOL: "tcp"</screen>
   46    </sect2>
   47  
   ..
  133      <para>
  134       After installation, create the configuration file
  135:      <filename>/etc/logstash/conf.d/00-scf.conf</filename>. In this example, we
  136:      will name it <filename>00-scf.conf</filename>. Add the following into the
  137       file. Take note of the port used in the input section. This value will
  138:      need to match the value of the <literal>SCF_LOG_PORT</literal> property in
  139       your &values-filename; file.
  140      </para>
  ...
  148    elasticsearch {
  149      hosts => ["localhost:9200"]
  150:     index => "scf-%{+YYYY.MM.dd}"
  151    }
  152  }

/home/lukas/work/doc-cap/xml/cap_admin_service_broker.xml:
  344        without starting it:
  345       </para>
  346:  <screen>&prompt.user;git clone https://github.com/scf-samples/cf-redis-example-app
  347   &prompt.user;cd cf-redis-example-app
  348   &prompt.user;cf push --no-start

/home/lukas/work/doc-cap/xml/cap_depl_aks.xml:
  592  
  593  <screen>
  594: &prompt.user;git clone https://github.com/scf-samples/question2answer
  595  
  596  &prompt.user;cd question2answer

/home/lukas/work/doc-cap/xml/cap_depl_eirini.xml:
   82      <para>
   83       To enable persistence, refer to the instructions at
   84:      <link xlink:href="https://github.com/SUSE/scf/wiki/Persistence-with-Eirini-in-SCF"/>.
   85      </para>
   86     </step>

/home/lukas/work/doc-cap/xml/entity-decl.ent:
   33  <!ENTITY caasp-url    "https://documentation.suse.com/suse-caasp/4.2">
   34  <!ENTITY cf           "Cloud Foundry">
   35: <!ENTITY scf          "&suse; Cloud Foundry">
   36  <!ENTITY uaa          "User Account and Authentication">
   37  <!ENTITY susemicros   "&suse; MicroOS">
   ..
  303          command.
  304      Do not re-use your old namespaces. The <command>helm delete</command> command
  305:     does not remove generated secrets from the SCF and UAA namespaces as it is
  306      not aware of them. These leftover secrets will cause problems. See
  307      <xref linkend="sec.cap.rebuild.depl"/> for more information.

/home/lukas/work/doc-cap/xml/repeated-content-decl.ent:
  439  <!ENTITY kubecf-deploy-complete
  440  '<para xmlns="http://docbook.org/ns/docbook">
  441:   Wait until you have a successful <literal>scf</literal> deployment before
  442    going to the next steps, which you can monitor with the
  443    <command>watch</command> command:
  ...
  507    <title>Deprecation of <literal>cflinuxfs2</literal> and <literal>sle12</literal> Stacks</title>
  508    <para>
  509:    As of &scf; 2.18.0, since our <literal>cf-deployment</literal> version is 9.5
  510     , the <literal>cflinuxfs2</literal> stack is no longer supported, as was
  511:    advised in &scf; 2.17.1 or &cap; 1.4.1. The <literal>cflinuxfs2</literal>
  512     buildpack is no longer shipped, but if you are upgrading from an earlier
  513     version, <literal>cflinuxfs2</literal> will not be removed. However, for

17 matches across 7 files
```