### PR TITLE
Fix simple-service diagram to display correct text label

### DIFF
--- a/images/src/svg/cap-simple-services.svg
+++ b/images/src/svg/cap-simple-services.svg
@@ -114,7 +114,7 @@
           <xhtml:div
              style="box-sizing: border-box; font-size: 0; text-align: center; ">
             <xhtml:div
-               style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #FF3333; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">SCF Network</xhtml:div>
+               style="display: inline-block; font-size: 12px; font-family: Helvetica; color: #FF3333; line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">KubeCF Network</xhtml:div>
           </xhtml:div>
         </xhtml:div>
       </foreignObject>


### PR DESCRIPTION
Amendment to https://github.com/SUSE/doc-cap/pull/865, which fixes #854  

When viewing the image using Inkscape the label correct shows "KubeCF Network", but the built version on the browser still showed "SCF Network".

Looking at the diff there was still an instance of "SCF Network" somehow??

This fixes the image at XML level.