### PR TITLE
Fix restore procedure

### DIFF
--- a/xml/cap_admin_backup-restore.xml
+++ b/xml/cap_admin_backup-restore.xml
@@ -733,7 +733,8 @@ secrets:
         If <literal>current_key_label</literal> was not set, create one for the
         new cluster through &values-filename; and set
         it to the <literal>$DB_ENCRYPTION_KEY</literal> value from the old
-        cluster. In this example, <literal>migrated_key</literal> is the new
+         cluster. Also set up the <literal>db_encryption_key</literal> bosh property
+         to use the previous key. In this example, <literal>migrated_key</literal> is the new
         <literal>current_key_label</literal> created:
        </para>
 <screen>env:
@@ -742,6 +743,15 @@ secrets:
 secrets:
   CC_DB_ENCRYPTION_KEYS:
     <replaceable>migrated_key</replaceable>: "<replaceable>OLD_CLUSTER_DB_ENCRYPTION_KEY</replaceable>"
+bosh:
+  instance_groups:
+  - name: api-group
+    jobs:
+    - name: cloud_controller_ng
+      properties:
+        cc:
+          db_encryption_key: "<replaceable>OLD_CLUSTER_DB_ENCRYPTION_KEY</replaceable>"
+
 </screen>
       </listitem>
      </itemizedlist>


### PR DESCRIPTION
When a cluster didn't had any key rotation in precedence we have also to force the db_encryption_key bosh property otherwise data cannot be decrypted.

I've tried the steps described in the docs for the restore process but failed - both in CAP 1.4.x (scf 2.16.4) and 1.5.X-  if the cluster which is backed up didn't had any rotation before the procedure, it fails also in a simple `cf apps`, and any further triggering of keys rotation don't work:

```
$> kubectl exec --namespace scf api-group-0 -- bash -c \
"source /var/vcap/jobs/cloud_controller_ng/bin/ruby_version.sh; \
export CLOUD_CONTROLLER_NG_CONFIG=/var/vcap/jobs/cloud_controller_ng/config/cloud_controller_ng.yml; \
cd /var/vcap/packages/cloud_controller_ng/cloud_controller_ng; \
bundle exec rake rotate_cc_database_key:perform"

rake aborted!
OpenSSL::Cipher::CipherError: bad decrypt
/var/vcap/packages/.src/1228a91aafec844dcf50aa5b0d6bbfa033a84644a822ddd9a427b7a4ed350e75/cloud_controller_ng/lib/cloud_controller/encryptor.rb:90:in `final'
/var/vcap/packages/.src/1228a91aafec844dcf50aa5b0d6bbfa033a84644a822ddd9a427b7a4ed350e75/cloud_controller_ng/lib/cloud_controller/encryptor.rb:90:in `run_cipher'
/var/vcap/packages/.src/1228a91aafec844dcf50aa5b0d6bbfa033a84644a822ddd9a427b7a4ed350e75/cloud_controller_ng/lib/cloud_controller/encryptor.rb:55:in `decrypt_raw'
/var/vcap/packages/.src/1228a91aafec844dcf50aa5b0d6bbfa033a84644a822ddd9a427b7a4ed350e75/cloud_controller_ng/lib/cloud_controller/encryptor.rb:51:in `decrypt'
/var/vcap/packages/.src/1228a91aafec844dcf50aa5b0d6bbfa033a84644a822ddd9a427b7a4ed350e75/cloud_controller_ng/lib/cloud_controller/encryptor.rb:181:in `block in set_field_as_encrypted'
/var/vcap/packages/.src/1228a91aafec844dcf50aa5b0d6bbfa033a84644a822ddd9a427b7a4ed350e75/cloud_controller_ng/lib/cloud_controller/serializer.rb:7:in `block in serializes_via_json'
/var/vcap/packages/.src/1228a91aafec844dcf50aa5b0d6bbfa033a84644a822ddd9a427b7a4ed350e75/cloud_controller_ng/lib/cloud_controller/errands/rotate_database_key.rb:68:in `public_send'
/var/vcap/packages/.src/1228a91aafec844dcf50aa5b0d6bbfa033a84644a822ddd9a427b7a4ed350e75/cloud_controller_ng/lib/cloud_controller/errands/rotate_database_key.rb:68:in `encrypt_field'
/var/vcap/packages/.src/1228a91aafec844dcf50aa5b0d6bbfa033a84644a822ddd9a427b7a4ed350e75/cloud_controller_ng/lib/cloud_controller/errands/rotate_database_key.rb:62:in `block in encrypt_row'
/var/vcap/packages/.src/1228a91aafec844dcf50aa5b0d6bbfa033a84644a822ddd9a427b7a4ed350e75/cloud_controller_ng/lib/cloud_controller/errands/rotate_database_key.rb:61:in `each'
/var/vcap/packages/.src/1228a91aafec844dcf50aa5b0d6bbfa033a84644a822ddd9a427b7a4ed350e75/cloud_controller_ng/lib/cloud_controller/errands/rotate_database_key.rb:61:in `encrypt_row'
/var/vcap/packages/.src/1228a91aafec844dcf50aa5b0d6bbfa033a84644a822ddd9a427b7a4ed350e75/cloud_controller_ng/lib/cloud_controller/errands/rotate_database_key.rb:48:in `block (2 levels) in rotate_batch'
/var/vcap/packages/.src/1228a91aafec844dcf50aa5b0d6bbfa033a84644a822ddd9a427b7a4ed350e75/gem_home/ruby/2.4.0/gems/sequel-5.16.0/lib/sequel/database/transactions.rb:245:in `_transaction'
/var/vcap/packages/.src/1228a91aafec844dcf50aa5b0d6bbfa033a84644a822ddd9a427b7a4ed350e75/gem_home/ruby/2.4.0/gems/sequel-5.16.0/lib/sequel/database/transactions.rb:220:in `block in transaction'
/var/vcap/packages/.src/1228a91aafec844dcf50aa5b0d6bbfa033a84644a822ddd9a427b7a4ed350e75/gem_home/ruby/2.4.0/gems/sequel-5.16.0/lib/sequel/database/connecting.rb:253:in `block in synchronize'
/var/vcap/packages/.src/1228a91aafec844dcf50aa5b0d6bbfa033a84644a822ddd9a427b7a4ed350e75/gem_home/ruby/2.4.0/gems/sequel-5.16.0/lib/sequel/connection_pool/threaded.rb:92:in `hold'
/var/vcap/packages/.src/1228a91aafec844dcf50aa5b0d6bbfa033a84644a822ddd9a427b7a4ed350e75/gem_home/ruby/2.4.0/gems/sequel-5.16.0/lib/sequel/database/connecting.rb:253:in `synchronize'
/var/vcap/packages/.src/1228a91aafec844dcf50aa5b0d6bbfa033a84644a822ddd9a427b7a4ed350e75/gem_home/ruby/2.4.0/gems/sequel-5.16.0/lib/sequel/database/transactions.rb:186:in `transaction'
/var/vcap/packages/.src/1228a91aafec844dcf50aa5b0d6bbfa033a84644a822ddd9a427b7a4ed350e75/cloud_controller_ng/lib/cloud_controller/errands/rotate_database_key.rb:45:in `block in rotate_batch'
/var/vcap/packages/.src/1228a91aafec844dcf50aa5b0d6bbfa033a84644a822ddd9a427b7a4ed350e75/cloud_controller_ng/lib/cloud_controller/errands/rotate_database_key.rb:44:in `each'
/var/vcap/packages/.src/1228a91aafec844dcf50aa5b0d6bbfa033a84644a822ddd9a427b7a4ed350e75/cloud_controller_ng/lib/cloud_controller/errands/rotate_database_key.rb:44:in `rotate_batch'
/var/vcap/packages/.src/1228a91aafec844dcf50aa5b0d6bbfa033a84644a822ddd9a427b7a4ed350e75/cloud_controller_ng/lib/cloud_controller/errands/rotate_database_key.rb:37:in `block in rotate_for_class'
/var/vcap/packages/.src/1228a91aafec844dcf50aa5b0d6bbfa033a84644a822ddd9a427b7a4ed350e75/cloud_controller_ng/lib/cloud_controller/errands/rotate_database_key.rb:31:in `loop'
/var/vcap/packages/.src/1228a91aafec844dcf50aa5b0d6bbfa033a84644a822ddd9a427b7a4ed350e75/cloud_controller_ng/lib/cloud_controller/errands/rotate_database_key.rb:31:in `rotate_for_class'
/var/vcap/packages/.src/1228a91aafec844dcf50aa5b0d6bbfa033a84644a822ddd9a427b7a4ed350e75/cloud_controller_ng/lib/cloud_controller/errands/rotate_database_key.rb:11:in `block in perform'
/var/vcap/packages/.src/1228a91aafec844dcf50aa5b0d6bbfa033a84644a822ddd9a427b7a4ed350e75/cloud_controller_ng/lib/cloud_controller/errands/rotate_database_key.rb:9:in `each'
/var/vcap/packages/.src/1228a91aafec844dcf50aa5b0d6bbfa033a84644a822ddd9a427b7a4ed350e75/cloud_controller_ng/lib/cloud_controller/errands/rotate_database_key.rb:9:in `perform'
/var/vcap/packages/.src/1228a91aafec844dcf50aa5b0d6bbfa033a84644a822ddd9a427b7a4ed350e75/cloud_controller_ng/lib/tasks/rotate_database_key.rake:7:in `block (2 levels) in <top (required)>'
/var/vcap/packages/cloud_controller_ng/gem_home/ruby/2.4.0/gems/rake-12.3.2/exe/rake:27:in `<top (required)>'
/var/vcap/packages/ruby-2.4-r5/bin/bundle:30:in `block in <main>'
/var/vcap/packages/ruby-2.4-r5/bin/bundle:22:in `<main>'
Tasks: TOP => rotate_cc_database_key:perform
(See full trace by running task with --trace)
{"timestamp":1591793813.3510966,"message":"Rotating encryption key for class VCAP::CloudController::AppModel","log_level":"info","source":"cc.rotate_database_key","data":{},"thread_id":46927294738260,"fiber_id":46927330853440,"process_id":2202,"file":"/var/vcap/packages/.src/1228a91aafec844dcf50aa5b0d6bbfa033a84644a822ddd9a427b7a4ed350e75/cloud_controller_ng/lib/cloud_controller/errands/rotate_database_key.rb","lineno":10,"method":"block in perform"}
{"timestamp":1591793813.3604841,"message":"199 rows of VCAP::CloudController::AppModel are not encrypted with the current key and will be rotated","log_level":"info","source":"cc.rotate_database_key","data":{},"thread_id":46927294738260,"fiber_id":46927330853440,"process_id":2202,"file":"/var/vcap/packages/.src/1228a91aafec844dcf50aa5b0d6bbfa033a84644a822ddd9a427b7a4ed350e75/cloud_controller_ng/lib/cloud_controller/errands/rotate_database_key.rb","lineno":30,"method":"rotate_for_class"}
{"timestamp":1591793813.384117,"message":"Error 'OpenSSL::Cipher::CipherError' occurred while updating record: VCAP::CloudController::AppModel, id: 301","log_level":"error","source":"cc.rotate_database_key","data":{},"thread_id":46927294738260,"fiber_id":46927330853440,"process_id":2202,"file":"/var/vcap/packages/.src/1228a91aafec844dcf50aa5b0d6bbfa033a84644a822ddd9a427b7a4ed350e75/cloud_controller_ng/lib/cloud_controller/errands/rotate_database_key.rb","lineno":53,"method":"rescue in block (2 levels) in rotate_batch"}
command terminated with exit code 1
```

To be able to  restore  it successfully, I had to change the steps.

After restoring the CCDB database in the new cluster, I've did an helm upgrade, with the following changes in scf values:

```
bosh:
  instance_groups:
  - name: api-group
    jobs:
    - name: cloud_controller_ng
      properties:
        cc:
          db_encryption_key: "old-db-key"
```

To note, the `db_encryption_key` value needs to be set with the cc database key of the old cluster which was retrieved during the steps described in the docs.

This is needed as the upstream docs [1] suggests to change `db_encryption_key`, in case there were no rotation in the original cluster.

Afterwards, you need to manually kill the api-group-0 pod to make pick it up the cloud_controller changes. This is not required in case you directly deploy scf with the above settings in the values file in place when creating the new cap instance.

I've checked this procedure and works for CAP 1.4.0 and 1.5.2
1: https://docs.cloudfoundry.org/adminguide/encrypting-cc-db.html#rotation