### PR TITLE
Fix SVGs preventing PDF build.

### DIFF
--- a/images/src/svg/cap-containers.svg
+++ b/images/src/svg/cap-containers.svg
@@ -61,17 +61,7 @@
        x="382.57458"
        y="702.05151"
        style="font-size:16px" /></text>
-  <flowRoot
-     xml:space="preserve"
-     id="flowRoot2352"
-     style="fill:black;fill-opacity:1;stroke:none;font-family:sans-serif;font-style:normal;font-weight:normal;font-size:24px;line-height:1.25;letter-spacing:0px;word-spacing:0px"><flowRegion
-       id="flowRegion2354"><rect
-         id="rect2356"
-         width="343.48264"
-         height="418.80206"
-         x="-372.70139"
-         y="141.54863" /></flowRegion><flowPara
-       id="flowPara2358"></flowPara></flowRoot>  <text
+<text
      xml:space="preserve"
      style="font-style:normal;font-weight:normal;font-size:26.66666794px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.00537181"
      x="357.60336"

--- a/images/src/svg/cap-kube.svg
+++ b/images/src/svg/cap-kube.svg
@@ -76,17 +76,7 @@
        id="tspan864"
        x="1006.379"
        y="321.71622">Services</tspan></text>
-  <flowRoot
-     xml:space="preserve"
-     id="flowRoot888"
-     style="font-style:normal;font-weight:normal;font-size:29.33333397px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"><flowRegion
-       id="flowRegion890"><rect
-         id="rect892"
-         width="93.915787"
-         height="42.688995"
-         x="-697.66016"
-         y="767.04413" /></flowRegion><flowPara
-       id="flowPara894">Operating</flowPara></flowRoot>  <text
+<text
      xml:space="preserve"
      style="font-style:normal;font-weight:normal;font-size:29.33333397px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#e3dbdb;fill-opacity:1;stroke:none"
      x="395.92831"


### PR DESCRIPTION
Fix PDF generation by removing the `flowRoot` elements from SVGs. Seems like the two removed elements were completely redundant. Tested in Okular, Chromium and Firefox.