### PR TITLE
Use example.com as system domain 

### DIFF
--- a/xml/repeated-content-decl.ent
+++ b/xml/repeated-content-decl.ent
@@ -1031,7 +1031,7 @@ agent.log</screen>
    <listitem>
     <para>
      The certificate&apos;s Subject Alternative Names (SAN) include the domain
-     <replaceable>*.cap.example.com</replaceable>, where <replaceable>cap.example.com</replaceable>
+     <replaceable>*.example.com</replaceable>, where <replaceable>example.com</replaceable>
      is replaced with the <literal>system_domain</literal> in your
      <filename>&values-file;</filename>.
     </para>
@@ -1869,7 +1869,7 @@ User:           username@ldap.example.com
 '<screen xmlns="http://docbook.org/ns/docbook">### example deployment configuration file
 ### &values-file;
 
-system_domain: cap.example.come
+system_domain: example.come
 
 credentials:
   cf_admin_password: <replaceable>changeme</replaceable>

--- a/xml/repeated-content-decl.ent
+++ b/xml/repeated-content-decl.ent
@@ -93,7 +93,7 @@ Before you start deploying &productname;, review the following documents:
   <para>
    When selecting a domain, &productname; expects <literal>DOMAIN</literal> to
    be either a subdomain or a root domain. Setting <literal>DOMAIN</literal> to
-   a top-level domain, such <literal>suse</literal>, is not supported.
+   a top-level domain, such as <literal>suse</literal>, is not supported.
   </para>
  </warning>'>
 


### PR DESCRIPTION
Closes #913 

Also reverts #920. 920 changed the example to use cap.example.com for consistency with the system_domain found in the values file example, but overall in the docs example.com is used as the example value.