### PR TITLE
Remove reference to NOTES.txt message. Not in current CAP releaase

### DIFF
--- a/xml/cap_user_cf_cli.xml
+++ b/xml/cap_user_cf_cli.xml
@@ -36,44 +36,9 @@
 
   <para>
    The following examples demonstrate some of the commonly-used commands. The
-   first task is to log into your new &suse; &cf; instance. When your
-   installation completes it prints a welcome screen with the information you
-   need to access it.
-  </para>
-
-<screen>       NOTES:
-    Welcome to your new deployment of &kubecf;.
-
-    The endpoint for use by the `cf` client is
-        https://api.example.com
-
-    To target this endpoint run
-        cf api --skip-ssl-validation https://api.example.com
-
-    Your administrative credentials are:
-        Username: admin
-        Password: password
-
-    Please remember, it may take some time for everything to come online.
-
-    You can use
-        kubectl get pods --namespace kubecf
-
-    to spot-check if everything is up and running, or
-        watch --color 'kubectl get pods --namespace kubecf'
-
-    to monitor continuously.</screen>
-
-  <para>
-   You can display this message anytime with this command:
-  </para>
-
-<screen>&prompt.user;helm status $(helm list | awk '/cf-([0-9]).([0-9]).*/{print$1}') | \
-sed --quiet --expression '/NOTES/,$p'</screen>
-
-  <para>
+   first task is to log into your new &cap; instance.
    You need to provide the API endpoint of your &productname; instance to log
-   in. The API endpoint is the <envar>DOMAIN</envar> value you provided in
+   in. The API endpoint is the <envar>system_domain</envar> value you provided in
    &values-filename;, plus the
    <literal>api.</literal> prefix, as it shows in the above welcome screen. Set
    your endpoint, and use <command>--skip-ssl-validation</command> when you


### PR DESCRIPTION
Closes https://github.com/SUSE/doc-cap/issues/893

Commented the below in https://github.com/SUSE/doc-cap/issues/893

```
Looks like the NOTES.txt (https://github.com/cloudfoundry-incubator/kubecf/blob/master/deploy/helm/kubecf/templates/NOTES.txt) didn't make it into the current release for KubeCF (https://github.com/SUSE/kubernetes-charts-suse-com/tree/master/stable/kubecf/templates) whereas it did for the operator (https://github.com/SUSE/kubernetes-charts-suse-com/tree/master/stable/cf-operator/templates).

Given that's the case, I've just removed the snippets referencing the message for the time being. They will be added back once the message is available again. The `helm` command will also need to be updated to include the namespace flag.
```