### PR TITLE
Re-enable external database section

### DIFF
--- a/xml/repeated-content-decl.ent
+++ b/xml/repeated-content-decl.ent
@@ -1387,10 +1387,10 @@ perl -ne &apos;/^sizing/..0 and do { print $.,":",$_ if /^ [a-z]/ || /high avail
   service provider or an existing high availability database server.
  </para>
  <para xmlns="http://docbook.org/ns/docbook">
-  To configure your deployment to use an external database, please contact
-  &suse; support or services for guidance.
+  To configure your deployment to use an external database, please follow the
+  instructions below.
  </para>
-<!--
+
  <para xmlns="http://docbook.org/ns/docbook">
   The current &productname; release is compatible with the following types of
   external databases:
@@ -1401,11 +1401,11 @@ perl -ne &apos;/^sizing/..0 and do { print $.,":",$_ if /^ [a-z]/ || /high avail
     &mysql;
    </para>
   </listitem>
-  <listitem>
+  <!-- <listitem>
    <para>
     &postgresql;
    </para>
-  </listitem>
+  </listitem> -->
  </itemizedlist>
  <sect2 xmlns="http://docbook.org/ns/docbook">
   <title>Configuration</title>
@@ -1429,16 +1429,17 @@ perl -ne &apos;/^sizing/..0 and do { print $.,":",$_ if /^ [a-z]/ || /high avail
    The following snippet of the <filename>&values-file;</filename>
    contains an example of an external database configuration.
   </para>
-<screen>features:
+<screen>
+features:
   embedded_database:
     enabled: false
   external_database:
     enabled: true
     require_ssl: false
     ca_cert: ~
-    type: ~
-    host: ~
-    port: ~
+    type: mysql
+    host: <replaceable>hostname</replaceable>
+    port: <replaceable>3306</replaceable>
     databases:
       uaa:
         name: uaa
@@ -1473,7 +1474,7 @@ perl -ne &apos;/^sizing/..0 and do { print $.,":",$_ if /^ [a-z]/ || /high avail
         password: <replaceable>root</replaceable>
         username: <replaceable>root</replaceable>
 </screen>
- </sect2>-->'>
+ </sect2>'>
 
 <!--ENTITY ldap..............................................................-->
 

--- a/xml/repeated-content-decl.ent
+++ b/xml/repeated-content-decl.ent
@@ -1426,6 +1426,12 @@ perl -ne &apos;/^sizing/..0 and do { print $.,":",$_ if /^ [a-z]/ || /high avail
    </para>
   </important>
   <para>
+    All the databases listed in the config snippet below need to exist before
+    installing &kubecf;. One way of doing that is manually running
+    <literal>CREATE DATABASE IF NOT EXISTS
+    <replaceable>database-name</replaceable></literal> for each database.
+  </para>
+  <para>
    The following snippet of the <filename>&values-file;</filename>
    contains an example of an external database configuration.
   </para>

--- a/xml/repeated-content-decl.ent
+++ b/xml/repeated-content-decl.ent
@@ -1392,13 +1392,13 @@ perl -ne &apos;/^sizing/..0 and do { print $.,":",$_ if /^ [a-z]/ || /high avail
  </para>
 
  <para xmlns="http://docbook.org/ns/docbook">
-  The current &productname; release is compatible with the following types of
-  external databases:
+  The current &productname; release is compatible with the following types and
+  versions of external databases:
  </para>
  <itemizedlist xmlns="http://docbook.org/ns/docbook">
   <listitem>
    <para>
-    &mysql;
+    &mysql; 5.7
    </para>
   </listitem>
   <!-- <listitem>


### PR DESCRIPTION
Closes #930 and re-enables content originally added by #618

Seems like there was an existing section describing how to enable external database, I just changed these:
* comment out PostgreSQL as I haven't tested it/wasn't required
* instead of telling the user to contact support, we tell them to follow the instructions
* fill in some extra values in the config

Missing:

- [ ] SSL support (confirmed not working currently)