### PR TITLE
Replace overly specific example with general advice.

### DIFF
--- a/xml/cap_admin_service_broker.xml
+++ b/xml/cap_admin_service_broker.xml
@@ -382,7 +382,8 @@
      with these and will need to be added during the <command>cf
      create-service</command> step using the <literal>-c</literal> flag. To find
      out the exact parameter to be used, reference the <literal>values.yaml</literal>
-     file in the upstream &helm; charts at https://github.com/helm/charts
+     file in the upstream &helm; charts at <link
+     xlink:href="https://github.com/helm/charts"/>
      located in the <literal>stable</literal> directory.
     </para>
    </important>

--- a/xml/cap_admin_service_broker.xml
+++ b/xml/cap_admin_service_broker.xml
@@ -380,14 +380,10 @@
      By default, Minibroker creates &postgresql; and &mariadb; server instances
      without a named database. A named database is required for normal usage
      with these and will need to be added during the <command>cf
-     create-service</command> step using the <literal>-c</literal> flag. For
-     example:
-    </para>
- <screen>&prompt.user;cf create-service postgresql 9-6-2 djangocms-db -c '{"postgresDatabase":"mydjango"}'
- &prompt.user;cf create-service mariadb 10-1-34 my-db  -c '{"mariadbDatabase":"mydb"}'
- </screen>
-    <para>
-     Other options can be set too, but vary by service type.
+     create-service</command> step using the <literal>-c</literal> flag. To find
+     out the exact parameter to be used, reference the <literal>values.yaml</literal>
+     file in the upstream &helm; charts at https://github.com/helm/charts
+     located in the <literal>stable</literal> directory.
     </para>
    </important>
   </sect2>


### PR DESCRIPTION
Replaces the specific advice how to create a named MySQL/MariaDB database with general advice on where to find charts and their values.yaml file.

If we have other cases where the user is better off looking at the upstream instead of being given an example that is bound to break often, it's worth considering adding a summary section that would describe where to find information upstream. The section could be in the Deployment and Administration Notes or the Troubleshooting section.