### PR TITLE
Add back air gap chapter

### DIFF
--- a/xml/book_cap_guides.xml
+++ b/xml/book_cap_guides.xml
@@ -53,7 +53,7 @@ Part: CAP Deployment Guide
   <xi:include href="cap_depl_gke.xml"/>
   <xi:include href="cap_depl_stratos.xml"/>
   <xi:include href="cap_depl_eirini.xml"/>
-  <!-- <xi:include href="cap_depl_air_gap_registry.xml"/> -->
+  <xi:include href="cap_depl_air_gap_registry.xml"/>
  </part>
 <!--============================================================================
 Part: CAP Administration Guide

--- a/xml/cap_depl_air_gap_registry.xml
+++ b/xml/cap_depl_air_gap_registry.xml
@@ -67,7 +67,7 @@
   </para>
 <screen>#!/bin/bash
 
-MIRROR=registry.home
+MIRROR=myregistry.com
 
 set -ex
 
@@ -87,9 +87,11 @@ function mirror {
     rm -r ${CHARTDIR}
 }
 
-mirror cf
+mirror cf-operator
+mirror kubecf
 mirror console
 mirror metrics
+mirror minibroker
 </screen>
   <para>
    The script above will both mirror to a local registry and save the images in
@@ -101,13 +103,6 @@ mirror metrics
    Also take note of the following regarding the script provided above.
   </para>
   <itemizedlist>
-   <listitem>
-    <para>
-     The <literal>minibroker</literal> chart is currently not supported as it
-     does not use a tagged image, but <literal>minibroker:latest</literal>. It
-     will use a tagged imaged in the next release and supported at that time.
-    </para>
-   </listitem>
    <listitem>
     <para>
      The <literal>nginx-ingress</literal> chart is not supported by this
@@ -131,7 +126,7 @@ mirror metrics
 <screen>kube:
   registry:
     # example registry domain
-    hostname: <replaceable>"registry.home"</replaceable>
+    hostname: <replaceable>"myregistry.com"</replaceable>
     username: ""
     password: ""
   organization: "cap"


### PR DESCRIPTION
The air gap chapter was previously removed for reasons I can't recall. This adds the chapter back and updates previous 1.x references to 2.x