### PR TITLE
entity: use generic caasp-url

### DIFF
--- a/.github/workflows/docbook.yml
+++ b/.github/workflows/docbook.yml
@@ -7,6 +7,7 @@ on:
       - 'xml/**'
       - 'adoc/**'
       - 'images/src/**'
+      - '.github/workflows/**'
       - '**/DC-*'
       - '**/xml/**'
       - '**/adoc/**'
@@ -56,6 +57,7 @@ jobs:
         with:
           dc-files: ${{ matrix.dc-files }}
           validate-ids: false
+          xml-schema: docbook51
 
 
   build-html:

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -31,7 +31,7 @@
 
 <!ENTITY caasp        "&suse; CaaS Platform">
 <!ENTITY susecaaspreg "&suse;&reg; CaaS Platform">
-<!ENTITY caasp-url    "https://documentation.suse.com/suse-caasp/4.5">
+<!ENTITY caasp-url    "https://documentation.suse.com/suse-caasp">
 <!ENTITY cf           "Cloud Foundry">
 <!ENTITY scf          "&suse; Cloud Foundry">
 <!ENTITY uaa          "User Account and Authentication">


### PR DESCRIPTION
Adjust the references to documentation.suse.com to point to the generic CaaSP doc page.   